### PR TITLE
Harden descartes session access and externalize Supabase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+js/config.js

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Si deseas ejecutar una copia de este proyecto, necesitarás tu propia instancia 
     * Crea un proyecto en [Supabase](https://supabase.com/).
     * Define el esquema de tus tablas (`visitantes`, `descartes_sesiones`, `equipos_descartados`) según la lógica de la aplicación.
     * Obtén tu **URL del Proyecto** y tu **Clave Pública (anon key)**.
-    * En el archivo `js/common.js`, reemplaza las variables `supabaseUrl` y `supabaseKey` con tus credenciales.
+    * Copia el archivo `js/config.example.js` a `js/config.js` (este último está ignorado por Git) y completa tus credenciales allí antes de abrir cualquiera de las páginas HTML.
+    * Asegúrate de usar únicamente la **clave pública (`anon`)** en ese archivo y de mantener activas tus políticas **RLS** antes de desplegar a producción.
 
 4.  **Abrir en el navegador:**
     * Abre el archivo `login.html` directamente en tu navegador.

--- a/consultar - copia.html
+++ b/consultar - copia.html
@@ -297,6 +297,7 @@
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 
   <!-- App -->
+  <script src="js/config.js"></script>
   <script src="js/common.js" defer></script>
   <script src="js/consultar.js" defer></script>
 

--- a/consultar.html
+++ b/consultar.html
@@ -307,6 +307,7 @@
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 
   <!-- App -->
+  <script src="js/config.js"></script>
   <script src="js/common.js" defer></script>
   <script src="js/consultar.js" defer></script>
 

--- a/descartes.html
+++ b/descartes.html
@@ -198,7 +198,8 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    
+
+    <script src="js/config.js"></script>
     <script src="js/scanbot/ScanbotSDK.min.js"></script>
     <script src="js/scanbot/ScanbotSDK.ui2.min.js"></script>
     

--- a/index.html
+++ b/index.html
@@ -160,6 +160,7 @@
     <script src="js/scanbot/ScanbotSDK.min.js"></script>
     <script src="js/scanbot/ScanbotSDK.ui2.min.js"></script>
     
+    <script src="js/config.js"></script>
     <script src="js/common.js" defer></script>
     <script src="js/script.js" defer></script>
 </body>

--- a/inicio.html
+++ b/inicio.html
@@ -54,6 +54,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="js/config.js"></script>
     <script src="js/common.js"></script>
     <script src="js/inicio.js"></script>
 </body>

--- a/js/common.js
+++ b/js/common.js
@@ -1,8 +1,14 @@
 // js/common.js
 
 // --- 1. CONFIGURACIÓN Y CLIENTE SUPABASE ---
-const supabaseUrl = "https://qmzbqwwndsdsmdkrimwb.supabase.co";
-const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFtemJxd3duZHNkc21ka3JpbXdiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY0OTExNDYsImV4cCI6MjA3MjA2NzE0Nn0.dfQdvfFbgXdun1kQ10gRsqh3treJRzOKdbkebpEQXWo";
+const supabaseConfig = window.__SUPABASE_CONFIG__ || {};
+
+if (!supabaseConfig.url || !supabaseConfig.key) {
+    throw new Error('Supabase no está configurado. Define window.__SUPABASE_CONFIG__ antes de cargar common.js');
+}
+
+const supabaseUrl = supabaseConfig.url;
+const supabaseKey = supabaseConfig.key;
 const supabaseClient = supabase.createClient(supabaseUrl, supabaseKey);
 
 // --- 2. INYECTOR DE BARRA DE NAVEGACIÓN ---

--- a/js/config.example.js
+++ b/js/config.example.js
@@ -1,0 +1,6 @@
+window.__SUPABASE_CONFIG__ = {
+  // URL del proyecto Supabase (por ejemplo: "https://xyzcompany.supabase.co")
+  url: 'https://TU-PROYECTO.supabase.co',
+  // Clave pública (anon) del proyecto
+  key: 'TU-CLAVE-ANON-PUBLICA'
+};

--- a/login.html
+++ b/login.html
@@ -76,6 +76,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="js/config.js"></script>
     <script src="js/common.js"></script>
     <script src="js/login.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- guard the descartes workflow behind an authenticated session and keep table numbering in sync after deletions
- move Supabase credentials into a configurable runtime file, ignore the private config, and document the setup flow
- load the new configuration file on each page that relies on the shared Supabase client

## Testing
- not run (static changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e134e9faac832a9cd33b24e72aad70