### PR TITLE
Versionar configuración pública de Supabase para despliegues estáticos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-js/config.js
+# Este archivo se deja intencionalmente vacío para permitir versionar js/config.js

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ Si deseas ejecutar una copia de este proyecto, necesitarás tu propia instancia 
     * Crea un proyecto en [Supabase](https://supabase.com/).
     * Define el esquema de tus tablas (`visitantes`, `descartes_sesiones`, `equipos_descartados`) según la lógica de la aplicación.
     * Obtén tu **URL del Proyecto** y tu **Clave Pública (anon key)**.
-    * Copia el archivo `js/config.example.js` a `js/config.js` (este último está ignorado por Git) y completa tus credenciales allí antes de abrir cualquiera de las páginas HTML.
+    * Copia el archivo `js/config.example.js` a `js/config.js` y completa tus credenciales allí antes de abrir cualquiera de las páginas HTML.
     * Asegúrate de usar únicamente la **clave pública (`anon`)** en ese archivo y de mantener activas tus políticas **RLS** antes de desplegar a producción.
+    * En despliegues estáticos como **GitHub Pages**, publica el archivo `js/config.js` dentro del repositorio que sirve la aplicación. La clave expuesta sigue protegida siempre que las políticas **RLS** permanezcan correctamente configuradas en Supabase.
 
 4.  **Abrir en el navegador:**
     * Abre el archivo `login.html` directamente en tu navegador.

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,4 @@
+window.__SUPABASE_CONFIG__ = {
+  url: 'https://qmzbqwwndsdsmdkrimwb.supabase.co',
+  key: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFtemJxd3duZHNkc21ka3JpbXdiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY0OTExNDYsImV4cCI6MjA3MjA2NzE0Nn0.dfQdvfFbgXdun1kQ10gRsqh3treJRzOKdbkebpEQXWo'
+};


### PR DESCRIPTION
## Summary
- allow tracking of `js/config.js` so the static build served from GitHub Pages loads the Supabase settings
- add the public Supabase URL and anon key used by the published site to the new `js/config.js`
- update the README with guidance on publishing the configuration file (protected by RLS) for static deployments

## Testing
- no automated tests were run (static configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68e14f970bd8832a85f4d54ed77fe838