### PR TITLE
Add session editing modal and totals to consult view

### DIFF
--- a/consultar - copia.html
+++ b/consultar - copia.html
@@ -47,6 +47,7 @@
           <div class="date-field">
             <input type="date" id="date-end-visitantes" placeholder="dd/mm/aaaa" title="Fecha de fin" />
           </div>
+          <span id="visitantes-total" class="count-pill" aria-live="polite">0 registros</span>
           <button id="export-visitantes-btn" class="btn-export">Exportar Excel</button>
         </div>
 
@@ -80,6 +81,7 @@
             <div class="date-field">
               <input type="date" id="date-end-descartes" placeholder="dd/mm/aaaa" title="Fecha de fin" />
             </div>
+            <span id="sesiones-total" class="count-pill" aria-live="polite">0 sesiones</span>
             <button id="export-descartes-btn" class="btn-export">Exportar Excel</button>
           </div>
 
@@ -120,6 +122,7 @@
               type="search"
               id="search-equipos"
               placeholder="Buscar por descripción, marca, modelo, serie o marbete..." />
+            <span id="equipos-total" class="count-pill" aria-live="polite">0 equipos</span>
             <!-- Botón para añadir equipo ahora ancho completo en móvil -->
             <button id="btn-agregar-equipo" class="btn-principal btn-anadir-equipo" type="button">Añadir Equipo</button>
           </div>
@@ -281,6 +284,44 @@
           <div class="modal-buttons">
             <button type="button" id="btn-agregar-equipo-cancelar" class="btn-secondary">Cancelar</button>
             <button type="submit" class="btn-principal">Añadir</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: Editar sesión de descarte -->
+  <div id="modal-editar-sesion" class="modal-overlay">
+    <div class="modal-content">
+      <button id="btn-cerrar-modal-editar-sesion" class="modal-close-btn">&times;</button>
+      <h2>Editar Sesión</h2>
+      <div class="modal-form-container">
+        <form id="form-editar-sesion" novalidate>
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="edit-sesion-unidad">Unidad Administrativa:</label>
+              <input type="text" id="edit-sesion-unidad" required />
+            </div>
+            <div class="form-group">
+              <label for="edit-sesion-siace">Código SIACE:</label>
+              <input type="text" id="edit-sesion-siace" />
+            </div>
+            <div class="form-group">
+              <label for="edit-sesion-fecha">Fecha:</label>
+              <input type="date" id="edit-sesion-fecha" required />
+            </div>
+            <div class="form-group">
+              <label for="edit-sesion-tecnico">Técnico Encargado:</label>
+              <input type="text" id="edit-sesion-tecnico" />
+            </div>
+          </div>
+          <div class="form-group-full">
+            <label for="edit-sesion-observacion">Observación:</label>
+            <textarea id="edit-sesion-observacion" rows="3"></textarea>
+          </div>
+          <div class="modal-buttons">
+            <button type="button" id="btn-editar-sesion-cancelar" class="btn-secondary modal-cancel-btn">Cancelar</button>
+            <button type="submit" class="btn-principal">Guardar Cambios</button>
           </div>
         </form>
       </div>

--- a/consultar.html
+++ b/consultar.html
@@ -47,6 +47,7 @@
           <div class="date-field">
             <input type="date" id="date-end-visitantes" placeholder="dd/mm/aaaa" title="Fecha de fin" />
           </div>
+          <span id="visitantes-total" class="count-pill" aria-live="polite">0 registros</span>
           <button id="export-visitantes-btn" class="btn-export">Exportar Excel</button>
         </div>
 
@@ -80,6 +81,7 @@
             <div class="date-field">
               <input type="date" id="date-end-descartes" placeholder="dd/mm/aaaa" title="Fecha de fin" />
             </div>
+            <span id="sesiones-total" class="count-pill" aria-live="polite">0 sesiones</span>
             <button id="export-descartes-btn" class="btn-export">Exportar Excel</button>
           </div>
 
@@ -130,6 +132,7 @@
               type="search"
               id="search-equipos"
               placeholder="Buscar por descripción, marca, modelo, serie o marbete..." />
+            <span id="equipos-total" class="count-pill" aria-live="polite">0 equipos</span>
             <!-- Botón Añadir Equipo se adapta a móvil -->
             <button id="btn-agregar-equipo" class="btn-principal btn-anadir-equipo" type="button">Añadir Equipo</button>
           </div>
@@ -291,6 +294,44 @@
           <div class="modal-buttons">
             <button type="button" id="btn-agregar-equipo-cancelar" class="btn-secondary">Cancelar</button>
             <button type="submit" class="btn-principal">Añadir</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: Editar sesión de descarte -->
+  <div id="modal-editar-sesion" class="modal-overlay">
+    <div class="modal-content">
+      <button id="btn-cerrar-modal-editar-sesion" class="modal-close-btn">&times;</button>
+      <h2>Editar Sesión</h2>
+      <div class="modal-form-container">
+        <form id="form-editar-sesion" novalidate>
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="edit-sesion-unidad">Unidad Administrativa:</label>
+              <input type="text" id="edit-sesion-unidad" required />
+            </div>
+            <div class="form-group">
+              <label for="edit-sesion-siace">Código SIACE:</label>
+              <input type="text" id="edit-sesion-siace" />
+            </div>
+            <div class="form-group">
+              <label for="edit-sesion-fecha">Fecha:</label>
+              <input type="date" id="edit-sesion-fecha" required />
+            </div>
+            <div class="form-group">
+              <label for="edit-sesion-tecnico">Técnico Encargado:</label>
+              <input type="text" id="edit-sesion-tecnico" />
+            </div>
+          </div>
+          <div class="form-group-full">
+            <label for="edit-sesion-observacion">Observación:</label>
+            <textarea id="edit-sesion-observacion" rows="3"></textarea>
+          </div>
+          <div class="modal-buttons">
+            <button type="button" id="btn-editar-sesion-cancelar" class="btn-secondary modal-cancel-btn">Cancelar</button>
+            <button type="submit" class="btn-principal">Guardar Cambios</button>
           </div>
         </form>
       </div>

--- a/css/consultar - copia.css
+++ b/css/consultar - copia.css
@@ -58,6 +58,30 @@ html.dark-mode .tabs-nav{
   box-shadow: 0 2px 10px var(--shadow-color);
 }
 
+.controls-area .count-pill {
+  margin-left: auto;
+}
+
+.count-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 0 16px;
+  border-radius: 999px;
+  background-color: color-mix(in srgb, var(--primary-color) 15%, transparent);
+  color: var(--primary-color);
+  font-weight: 600;
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+html.dark-mode .count-pill {
+  background-color: color-mix(in srgb, var(--primary-color) 30%, transparent);
+  color: #fff;
+}
+
 /* Inputs con look de cápsula */
 .controls-area input[type="search"],
 .controls-area .date-field input[type="date"]{
@@ -259,6 +283,13 @@ html.dark-mode {
 
   .controls-area .btn-export { grid-column: 1 / -1; width: 100%; }
 
+  .controls-area .count-pill {
+    grid-column: 1 / -1;
+    width: 100%;
+    margin-left: 0;
+    justify-content: center;
+  }
+
   /* En móvil, conserva el mismo alto/padding y oculta flechas nativas */
   .controls-area .date-field { width: 100%; }
   .controls-area .date-field input[type="date"] {
@@ -432,7 +463,7 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
   #btn-volver-sesiones {
     padding: 6px 12px;
     font-size: 0.85rem;
-    border-radius: 8px;
+    border-radius: var(--button-radius);
   }
 }
 

--- a/css/consultar.css
+++ b/css/consultar.css
@@ -58,6 +58,30 @@ html.dark-mode .tabs-nav{
   box-shadow: 0 2px 10px var(--shadow-color);
 }
 
+.controls-area .count-pill {
+  margin-left: auto;
+}
+
+.count-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 0 16px;
+  border-radius: 999px;
+  background-color: color-mix(in srgb, var(--primary-color) 15%, transparent);
+  color: var(--primary-color);
+  font-weight: 600;
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+html.dark-mode .count-pill {
+  background-color: color-mix(in srgb, var(--primary-color) 30%, transparent);
+  color: #fff;
+}
+
 /* Inputs con look de cápsula */
 .controls-area input[type="search"],
 .controls-area .date-field input[type="date"]{
@@ -444,7 +468,7 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
     display: inline-block;
     padding: 6px 12px;
     font-size: 0.85rem;
-    border-radius: 8px;
+    border-radius: var(--button-radius);
     background-color: var(--primary-color);
     color: #fff;
     border: none;
@@ -476,7 +500,16 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
   #btn-volver-sesiones {
     padding: 6px 12px;
     font-size: 0.85rem;
-    border-radius: 8px;
+    border-radius: var(--button-radius);
+  }
+}
+
+@media (max-width: 768px) {
+  .controls-area .count-pill {
+    grid-column: 1 / -1;
+    width: 100%;
+    margin-left: 0;
+    justify-content: center;
   }
 }
 

--- a/css/descartes.css
+++ b/css/descartes.css
@@ -85,7 +85,7 @@
     background-color: var(--primary-color);
     color: white;
     border: none;
-    border-radius: 6px;
+    border-radius: var(--button-radius);
     cursor: pointer;
     font-size: 1.1rem;
     font-weight: bold;
@@ -137,7 +137,7 @@
 .btn-accion {
     border: none;
     padding: 5px 10px;
-    border-radius: 5px;
+    border-radius: var(--button-radius);
     cursor: pointer;
     font-size: 0.8rem;
     color: white;
@@ -184,7 +184,7 @@
     background-color: var(--success-color);
     color: white;
     border: none;
-    border-radius: 8px;
+    border-radius: var(--button-radius);
     cursor: pointer;
     font-size: 1.2rem;
     font-weight: bold;

--- a/css/global.css
+++ b/css/global.css
@@ -11,6 +11,7 @@
     --shadow-color: rgba(0, 0, 0, 0.05);
     --success-color: #28A745;
     --error-color: #DC3545;
+    --button-radius: 12px;
 }
 
 html.dark-mode {
@@ -39,6 +40,10 @@ body {
     color: var(--text-color);
     transition: background-color 0.2s ease-in-out;
     padding-top: 0;
+}
+
+button {
+    border-radius: var(--button-radius);
 }
 
 .loader-wrapper {
@@ -274,7 +279,7 @@ body.nav-open .nav-links {
     background: transparent;
     border: none;
     cursor: pointer;
-    border-radius: 5px;
+    border-radius: var(--button-radius);
     transition: background-color 0.2s;
     display: flex;
     align-items: center;
@@ -489,7 +494,7 @@ body.nav-open .icon-menu { display: none; }
 .btn-secondary, .btn-danger {
     padding: 10px 25px;
     border: none;
-    border-radius: 6px;
+    border-radius: var(--button-radius);
     font-size: 1rem;
     font-weight: bold;
     cursor: pointer;
@@ -569,7 +574,7 @@ html.dark-mode input:-webkit-autofill {
 .btn-principal {
   padding: 10px 25px;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--button-radius);
   font-size: 1rem;
   font-weight: 700;
   cursor: pointer;

--- a/css/login.css
+++ b/css/login.css
@@ -102,7 +102,7 @@ body.dark-mode .login-container {
     background-color: var(--primary-color);
     color: white;
     border: none;
-    border-radius: 6px;
+    border-radius: var(--button-radius);
     cursor: pointer;
     font-size: 1rem;
     font-weight: bold;
@@ -126,7 +126,7 @@ body.dark-mode .login-container {
     background-color: transparent;
     color: var(--primary-color);
     border: 1px solid var(--primary-color);
-    border-radius: 6px;
+    border-radius: var(--button-radius);
     cursor: pointer;
     font-size: 1rem;
     font-weight: bold;

--- a/css/registro.css
+++ b/css/registro.css
@@ -31,7 +31,7 @@
     background-color: var(--primary-color);
     color: white;
     border: none;
-    border-radius: 6px;
+    border-radius: var(--button-radius);
     cursor: pointer;
     font-size: 1.1rem;
     font-weight: bold;

--- a/js/consultar.js
+++ b/js/consultar.js
@@ -52,11 +52,27 @@ document.addEventListener('DOMContentLoaded', async () => {
   const btnCancelarEditarEq      = document.getElementById('btn-editar-equipo-cancelar');
 
   // --- NUEVO: Modal agregar equipo ---
-const btnAgregarEquipo         = document.getElementById('btn-agregar-equipo');
-const modalAgregarEquipo       = document.getElementById('modal-agregar-equipo');
-const formAgregarEquipo        = document.getElementById('form-agregar-equipo');
-const btnCerrarModalAgregarEq  = document.getElementById('btn-cerrar-modal-agregar-equipo');
-const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-cancelar');
+  const btnAgregarEquipo         = document.getElementById('btn-agregar-equipo');
+  const modalAgregarEquipo       = document.getElementById('modal-agregar-equipo');
+  const formAgregarEquipo        = document.getElementById('form-agregar-equipo');
+  const btnCerrarModalAgregarEq  = document.getElementById('btn-cerrar-modal-agregar-equipo');
+  const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-cancelar');
+
+  // Contadores
+  const visitantesTotalEl        = document.getElementById('visitantes-total');
+  const sesionesTotalEl          = document.getElementById('sesiones-total');
+  const equiposTotalEl           = document.getElementById('equipos-total');
+
+  // Modal editar sesión
+  const modalEditarSesion        = document.getElementById('modal-editar-sesion');
+  const formEditarSesion         = document.getElementById('form-editar-sesion');
+  const btnCerrarModalEditarSes  = document.getElementById('btn-cerrar-modal-editar-sesion');
+  const btnCancelarEditarSesion  = document.getElementById('btn-editar-sesion-cancelar');
+  const editSesionUnidadInput    = document.getElementById('edit-sesion-unidad');
+  const editSesionSiaceInput     = document.getElementById('edit-sesion-siace');
+  const editSesionFechaInput     = document.getElementById('edit-sesion-fecha');
+  const editSesionTecnicoInput   = document.getElementById('edit-sesion-tecnico');
+  const editSesionObservacionInput = document.getElementById('edit-sesion-observacion');
 
   // Toast
   const toastEl        = document.getElementById('toast-notification');
@@ -68,7 +84,9 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
   let currentEquiposData    = [];
   let editingVisitorId      = null;
   let editingEquipoId       = null;
+  let editingSessionId      = null;
   let currentSessionId      = null;
+  let currentSessionEquiposTotal = 0;
   let searchDebounceTimeout;
   let toastTimeout;
 
@@ -103,6 +121,48 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
     }).format(date);
   }
 
+  function pluralize(count, singular, plural = `${singular}s`) {
+    const label = count === 1 ? singular : plural;
+    return `${count} ${label}`;
+  }
+
+  function updateVisitantesTotal(count) {
+    if (!visitantesTotalEl) return;
+    visitantesTotalEl.textContent = pluralize(count, 'registro');
+  }
+
+  function updateSesionesTotal(count) {
+    if (!sesionesTotalEl) return;
+    sesionesTotalEl.textContent = pluralize(count, 'sesión', 'sesiones');
+  }
+
+  function updateEquiposTotalBadge(visibleCount = currentEquiposData.length) {
+    if (!equiposTotalEl) return;
+
+    if (!currentSessionId) {
+      const base = currentSessionEquiposTotal || visibleCount || 0;
+      equiposTotalEl.textContent = pluralize(base, 'equipo');
+      return;
+    }
+
+    const total = typeof currentSessionEquiposTotal === 'number'
+      ? currentSessionEquiposTotal
+      : visibleCount;
+
+    if (!total && !visibleCount) {
+      equiposTotalEl.textContent = '0 equipos';
+      return;
+    }
+
+    if (total && total !== visibleCount) {
+      const totalLabel = pluralize(total, 'equipo');
+      equiposTotalEl.textContent = `${visibleCount} de ${totalLabel}`;
+    } else {
+      const base = total || visibleCount || 0;
+      equiposTotalEl.textContent = pluralize(base, 'equipo');
+    }
+  }
+
   // --- 4) Datos y render ---
 
   // Visitantes
@@ -126,6 +186,7 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
     if (error) {
       showToast('Error al cargar los visitantes.', 'error');
       console.error(error);
+      updateVisitantesTotal(0);
       return;
     }
     currentVisitorData = data || [];
@@ -134,6 +195,7 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
 
   function renderVisitantesTable(data) {
     if (!tableVisitantesBody) return;
+    updateVisitantesTotal(data.length);
     tableVisitantesBody.innerHTML = '';
     if (!data.length) {
       tableVisitantesBody.innerHTML = '<tr><td colspan="7">No se encontraron registros.</td></tr>';
@@ -178,6 +240,7 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
     if (error) {
       showToast('Error al cargar las sesiones de descarte.', 'error');
       console.error(error);
+      updateSesionesTotal(0);
       return;
     }
     currentDescartesData = data || [];
@@ -186,6 +249,7 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
 
   function renderDescartesTable(data) {
     if (!tableDescartesBody) return;
+    updateSesionesTotal(data.length);
     tableDescartesBody.innerHTML = '';
     if (!data.length) {
       tableDescartesBody.innerHTML = '<tr><td colspan="7">No se encontraron sesiones.</td></tr>';
@@ -203,6 +267,7 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
         <td>${count}</td>
         <td class="table-actions">
           <button class="btn-view-equipos"    data-id="${session.id}">Abrir</button>
+          <button class="btn-editar btn-editar-sesion" data-id="${session.id}">Editar</button>
           <button class="btn-eliminar-sesion" data-id="${session.id}">Eliminar</button>
         </td>
       `;
@@ -242,11 +307,31 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
     return data || [];
   }
 
+  async function refreshSessionEquiposTotal(sessionId) {
+    if (!sessionId) {
+      currentSessionEquiposTotal = 0;
+      return;
+    }
+
+    const { count, error } = await supabaseClient
+      .from('equipos_descartados')
+      .select('*', { count: 'exact', head: true })
+      .eq('sesion_id', sessionId);
+
+    if (error) {
+      console.error('No se pudo obtener el total de equipos de la sesión.', error);
+      return;
+    }
+
+    currentSessionEquiposTotal = count || 0;
+  }
+
   function renderEquiposTable(equipos) {
     if (!tableEquiposSesionBody) return;
     tableEquiposSesionBody.innerHTML = '';
     if (!equipos.length) {
       tableEquiposSesionBody.innerHTML = '<tr><td colspan="9">No hay equipos en esta sesión.</td></tr>';
+      updateEquiposTotalBadge(0);
       return;
     }
     equipos.forEach((eq, i) => {
@@ -267,15 +352,18 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
       `;
       tableEquiposSesionBody.appendChild(tr);
     });
+    updateEquiposTotalBadge(equipos.length);
   }
 
   async function openSessionDetail(sessionId) {
-    currentSessionId = sessionId;
+    const parsedId = Number(sessionId);
+    const sessionKey = Number.isNaN(parsedId) ? sessionId : parsedId;
+    currentSessionId = sessionKey;
 
     const { data: sesion, error } = await supabaseClient
       .from('descartes_sesiones')
       .select('id, unidad_administrativa, codigo_siace, fecha, tecnico_encargado, observacion')
-      .eq('id', sessionId)
+      .eq('id', sessionKey)
       .single();
 
     if (error || !sesion) {
@@ -293,18 +381,25 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
     if (sesionesListaSection) sesionesListaSection.style.display = 'none';
     if (sesionDetalleSection) sesionDetalleSection.style.display = 'block';
 
+    await refreshSessionEquiposTotal(sessionKey);
     const term = searchEquiposInput?.value.trim() || '';
-    currentEquiposData = await fetchEquiposBySession(sessionId, term);
+    currentEquiposData = await fetchEquiposBySession(sessionKey, term);
     renderEquiposTable(currentEquiposData);
   }
 
   function closeSessionDetail() {
     currentSessionId   = null;
     currentEquiposData = [];
+    currentSessionEquiposTotal = 0;
     if (searchEquiposInput) searchEquiposInput.value = '';
     if (sesionDetalleSection) sesionDetalleSection.style.display = 'none';
     if (sesionesListaSection) sesionesListaSection.style.display = 'block';
+    updateEquiposTotalBadge(0);
   }
+
+  updateVisitantesTotal(0);
+  updateSesionesTotal(0);
+  updateEquiposTotalBadge(0);
 
   // --- 5) Eventos ---
 
@@ -417,15 +512,101 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
     });
   }
 
+  if (formEditarSesion) {
+    formEditarSesion.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (!editingSessionId) {
+        showToast('No hay sesión seleccionada.', 'error');
+        return;
+      }
+
+      const unidad = editSesionUnidadInput?.value.trim() || '';
+      const siace = editSesionSiaceInput?.value.trim() || '';
+      const fecha = editSesionFechaInput?.value || '';
+      const tecnico = editSesionTecnicoInput?.value.trim() || '';
+      const observacion = editSesionObservacionInput?.value.trim() || '';
+
+      if (!unidad || !fecha) {
+        showToast('Completa los campos de Unidad y Fecha.', 'error');
+        return;
+      }
+
+      const payload = {
+        unidad_administrativa: unidad,
+        codigo_siace: siace || null,
+        fecha,
+        tecnico_encargado: tecnico || null,
+        observacion: observacion || null,
+      };
+
+      const { error } = await supabaseClient
+        .from('descartes_sesiones')
+        .update(payload)
+        .eq('id', editingSessionId);
+
+      if (error) {
+        console.error(error);
+        showToast('No se pudo actualizar la sesión.', 'error');
+        return;
+      }
+
+      showToast('Sesión actualizada con éxito.', 'success');
+      modalEditarSesion?.classList.remove('visible');
+
+      await fetchDescartes();
+
+      if (currentSessionId && Number(currentSessionId) === editingSessionId) {
+        await openSessionDetail(currentSessionId);
+      }
+
+      editingSessionId = null;
+    });
+  }
+
   // Acciones tabla sesiones
   if (tableDescartesBody) {
     tableDescartesBody.addEventListener('click', async (e) => {
       const btnOpen = e.target.closest('.btn-view-equipos');
       const btnDel  = e.target.closest('.btn-eliminar-sesion');
+      const btnEdit = e.target.closest('.btn-editar-sesion');
 
       if (btnOpen) {
         const sessionId = btnOpen.dataset.id;
         await openSessionDetail(sessionId);
+        return;
+      }
+
+      if (btnEdit) {
+        const sessionId = Number(btnEdit.dataset.id);
+        let sessionData = currentDescartesData.find(s => s.id === sessionId);
+
+        if (!sessionData) {
+          const { data, error } = await supabaseClient
+            .from('descartes_sesiones')
+            .select('id, unidad_administrativa, codigo_siace, fecha, tecnico_encargado, observacion')
+            .eq('id', sessionId)
+            .single();
+
+          if (error || !data) {
+            showToast('No se pudieron cargar los datos de la sesión.', 'error');
+            return;
+          }
+          sessionData = data;
+        }
+
+        if (!modalEditarSesion || !formEditarSesion) {
+          showToast('El formulario de edición de sesión no está disponible.', 'error');
+          return;
+        }
+
+        editingSessionId = sessionId;
+        if (editSesionUnidadInput)    editSesionUnidadInput.value    = sessionData.unidad_administrativa || '';
+        if (editSesionSiaceInput)     editSesionSiaceInput.value     = sessionData.codigo_siace || '';
+        if (editSesionFechaInput)     editSesionFechaInput.value     = sessionData.fecha || '';
+        if (editSesionTecnicoInput)   editSesionTecnicoInput.value   = sessionData.tecnico_encargado || '';
+        if (editSesionObservacionInput) editSesionObservacionInput.value = sessionData.observacion || '';
+
+        modalEditarSesion.classList.add('visible');
         return;
       }
 
@@ -480,6 +661,9 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
           } else {
             showToast('Equipo eliminado.', 'success');
             const term = searchEquiposInput?.value.trim() || '';
+            if (currentSessionId) {
+              await refreshSessionEquiposTotal(currentSessionId);
+            }
             currentEquiposData = await fetchEquiposBySession(currentSessionId, term);
             renderEquiposTable(currentEquiposData);
           }
@@ -556,6 +740,18 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
   if (btnCancelarEditarEq) {
     btnCancelarEditarEq.addEventListener('click', () => modalEditarEquipo?.classList.remove('visible'));
   }
+  if (btnCerrarModalEditarSes) {
+    btnCerrarModalEditarSes.addEventListener('click', () => {
+      modalEditarSesion?.classList.remove('visible');
+      editingSessionId = null;
+    });
+  }
+  if (btnCancelarEditarSesion) {
+    btnCancelarEditarSesion.addEventListener('click', () => {
+      modalEditarSesion?.classList.remove('visible');
+      editingSessionId = null;
+    });
+  }
   document.querySelectorAll('.modal-overlay').forEach(modal => {
     modal.addEventListener('click', e => {
       if (
@@ -564,6 +760,9 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
         e.target.classList.contains('modal-cancel-btn')
       ) {
         modal.classList.remove('visible');
+        if (modal === modalEditarSesion) {
+          editingSessionId = null;
+        }
       }
     });
   });
@@ -624,6 +823,9 @@ const btnCancelarAgregarEq     = document.getElementById('btn-agregar-equipo-can
         showToast("Equipo agregado con éxito.", "success");
         modalAgregarEquipo.classList.remove('visible');
         const term = searchEquiposInput?.value.trim() || '';
+        if (currentSessionId) {
+          await refreshSessionEquiposTotal(currentSessionId);
+        }
         currentEquiposData = await fetchEquiposBySession(currentSessionId, term);
         renderEquiposTable(currentEquiposData);
       }


### PR DESCRIPTION
## Summary
- unify button styling with a shared border radius variable and apply it across affected pages
- add visitor, session, and equipment counters to the consult filters with matching styles (including the duplicate template)
- implement a session metadata edit modal and update logic that keeps equipment totals in sync after CRUD actions

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e1564450d8832a9238ebbd9608a2ac