### PR TITLE
Fix mobile date placeholder visibility

### DIFF
--- a/css/consultar.css
+++ b/css/consultar.css
@@ -256,7 +256,7 @@ html.dark-mode {
 
 /* --- Placeholder móvil visible en date --- */
 @media (max-width: 768px) {
-  input[type="date"]:not(:focus):not(:valid)::before {
+  input[type="date"]:not(:focus):placeholder-shown::before {
     content: attr(placeholder);
     color: #888;
     margin-left: 10px;


### PR DESCRIPTION
## Summary
- update the mobile-only placeholder rule for date inputs to rely on :placeholder-shown so the dd/mm/aaaa text renders when fields are empty

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e17404fa18832a9d926e3f9a412876