### PR TITLE
Add explicit date placeholders for mobile browsers

### DIFF
--- a/consultar.html
+++ b/consultar.html
@@ -41,11 +41,13 @@
       <div id="visitantes-content" class="tab-content active">
         <div class="controls-area">
           <input type="search" id="search-visitantes" placeholder="Buscar por nombre, apellido o cédula..." />
-          <div class="date-field">
+          <div class="date-field" data-empty="true">
             <input type="date" id="date-start-visitantes" placeholder="dd/mm/aaaa" title="Fecha de inicio" />
+            <span class="date-placeholder" aria-hidden="true">dd/mm/aaaa</span>
           </div>
-          <div class="date-field">
+          <div class="date-field" data-empty="true">
             <input type="date" id="date-end-visitantes" placeholder="dd/mm/aaaa" title="Fecha de fin" />
+            <span class="date-placeholder" aria-hidden="true">dd/mm/aaaa</span>
           </div>
           <span id="visitantes-total" class="count-pill" aria-live="polite">0 registros</span>
           <button id="export-visitantes-btn" class="btn-export">Exportar Excel</button>
@@ -75,11 +77,13 @@
         <section id="sesiones-lista">
           <div class="controls-area">
             <input type="search" id="search-descartes" placeholder="Buscar por Unidad Administrativa o SIACE..." />
-            <div class="date-field">
+            <div class="date-field" data-empty="true">
               <input type="date" id="date-start-descartes" placeholder="dd/mm/aaaa" title="Fecha de inicio" />
+              <span class="date-placeholder" aria-hidden="true">dd/mm/aaaa</span>
             </div>
-            <div class="date-field">
+            <div class="date-field" data-empty="true">
               <input type="date" id="date-end-descartes" placeholder="dd/mm/aaaa" title="Fecha de fin" />
+              <span class="date-placeholder" aria-hidden="true">dd/mm/aaaa</span>
             </div>
             <span id="sesiones-total" class="count-pill" aria-live="polite">0 sesiones</span>
             <button id="export-descartes-btn" class="btn-export">Exportar Excel</button>

--- a/css/consultar.css
+++ b/css/consultar.css
@@ -190,6 +190,22 @@ html.dark-mode .date-field input[type="date"]{
   height: 42px;
 }
 
+.controls-area .date-field .date-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  color: color-mix(in srgb, var(--input-text-color) 45%, transparent);
+  pointer-events: none;
+  transition: opacity .2s ease;
+}
+
+.controls-area .date-field[data-empty="false"] .date-placeholder,
+.controls-area .date-field:focus-within .date-placeholder {
+  opacity: 0;
+}
+
 /* Input ocupa todo el wrapper y deja espacio al ícono */
 .controls-area .date-field input[type="date"] {
   width: 100%;
@@ -252,15 +268,6 @@ html.dark-mode {
 .controls-area .date-field,
 .controls-area .date-field::after {
   cursor: pointer;
-}
-
-/* --- Placeholder móvil visible en date --- */
-@media (max-width: 768px) {
-  input[type="date"]:not(:focus):placeholder-shown::before {
-    content: attr(placeholder);
-    color: #888;
-    margin-left: 10px;
-  }
 }
 
 /* --- Ajuste de grilla en móvil para filtros --- */


### PR DESCRIPTION
## Summary
- render `dd/mm/aaaa` placeholders as inline spans inside each date filter wrapper so they appear on mobile devices
- style the helper span to overlay the custom calendar input without affecting click behaviour and remove the pseudo-element hack

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e17afc8de8832a9b1f2dc4f2faa108