### PR TITLE
Adjust mobile login layout spacing

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -159,6 +159,14 @@ body.dark-mode .login-container {
 
 /* Responsivo */
 @media (max-width: 768px) {
+    .login-page-main {
+        min-height: auto;
+        height: auto;
+        justify-content: flex-start;
+        align-items: stretch;
+        padding-top: 40px;
+        padding-bottom: 40px;
+    }
     .page-main-title { font-size: 1.3rem; margin-bottom: 25px; }
     .login-container { flex-direction: column; max-width: 400px; }
     .login-info { text-align: center; align-items: center; padding: 20px; }


### PR DESCRIPTION
## Summary
- override the login page container styles on small screens to remove viewport-bound heights
- add vertical padding so the layout keeps comfortable spacing without fixed view height

## Testing
- browser_container.run_playwright_script mobile flow check

------
https://chatgpt.com/codex/tasks/task_e_68e19248b5c0832a8e31c2a6ec6ea474