### PR TITLE
Improve mobile login flow layout

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -121,6 +121,14 @@ main {
     padding: 80px 20px 20px 20px;
 }
 
+@media (max-width: 768px) {
+    main {
+        display: block;
+        min-height: auto;
+        padding: 60px 20px 120px 20px;
+    }
+}
+
 @media (min-width: 768px) {
     main {
         justify-content: center;

--- a/css/login.css
+++ b/css/login.css
@@ -1,5 +1,10 @@
 /* --- Estilos para la Página de Login --- */
 
+/* Utilidades */
+.is-hidden {
+    display: none !important;
+}
+
 /* Contenedor principal de la página de login */
 .login-page-main {
     display: flex;

--- a/js/login.js
+++ b/js/login.js
@@ -24,6 +24,31 @@ document.addEventListener('DOMContentLoaded', () => {
     const backBtn = document.getElementById('back-btn');
     const loginBtn = document.getElementById('login-btn');
 
+    const focusField = (field) => {
+        requestAnimationFrame(() => {
+            if (typeof field.focus === 'function') {
+                try {
+                    field.focus({ preventScroll: true });
+                } catch (error) {
+                    field.focus();
+                }
+            }
+            if (typeof field.scrollIntoView === 'function') {
+                try {
+                    field.scrollIntoView({ block: 'center', behavior: 'smooth' });
+                } catch (error) {
+                    field.scrollIntoView();
+                }
+            }
+        });
+    };
+
+    const toggleStepVisibility = (stepToHide, stepToShow, fieldToFocus) => {
+        stepToHide.classList.add('is-hidden');
+        stepToShow.classList.remove('is-hidden');
+        focusField(fieldToFocus);
+    };
+
     // --- LÓGICA DEL FORMULARIO MULTI-PASO ---
     nextBtn.addEventListener('click', () => {
         const email = emailInput.value.trim();
@@ -33,15 +58,11 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         loginError.style.display = 'none';
-        stepEmail.style.display = 'none';
-        stepPassword.style.display = 'flex';
-        passwordInput.focus();
+        toggleStepVisibility(stepEmail, stepPassword, passwordInput);
     });
 
     backBtn.addEventListener('click', () => {
-        stepPassword.style.display = 'none';
-        stepEmail.style.display = 'block';
-        emailInput.focus();
+        toggleStepVisibility(stepPassword, stepEmail, emailInput);
     });
 
     // --- LÓGICA DE ENVÍO FINAL ---
@@ -78,9 +99,9 @@ document.addEventListener('DOMContentLoaded', () => {
             loadingOverlay.classList.remove('visible');
             loginError.textContent = 'Correo o contraseña incorrectos.';
             loginError.style.display = 'block';
-            
+
             passwordInput.value = '';
-            passwordInput.focus();
+            focusField(passwordInput);
             
             loginBtn.disabled = false;
             backBtn.disabled = false;

--- a/login.html
+++ b/login.html
@@ -55,7 +55,7 @@
                         <button type="button" id="next-btn" class="btn-primary">Siguiente</button>
                     </div>
 
-                    <div id="step-password" style="display: none;">
+                    <div id="step-password" class="is-hidden">
                         <label for="password">Contraseña:</label>
                         <input type="password" id="password" required>
                         <div class="form-buttons">


### PR DESCRIPTION
## Summary
- preserve the flex-based spacing in the login wizard by using a shared `.is-hidden` class and removing inline `display` overrides
- defer focus/scroll logic when changing steps so mobile keyboards stay open and fields remain visible
- let `main` collapse on small screens with extra bottom padding to stop the keyboard from hiding submit buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19597eb20832a97c4f8ec9fafa38a