### PR TITLE
Disable login field autofocus on mobile devices

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -26,7 +26,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const focusField = (field) => {
         requestAnimationFrame(() => {
-            if (typeof field.focus === 'function') {
+            const isMobileView = window.matchMedia('(max-width: 768px)').matches ||
+                window.matchMedia('(pointer: coarse)').matches;
+
+            if (!isMobileView && typeof field.focus === 'function') {
                 try {
                     field.focus({ preventScroll: true });
                 } catch (error) {


### PR DESCRIPTION
## Summary
- add a mobile viewport detection guard inside the login focus helper
- keep smooth scrolling for both mobile and desktop while disabling autofocus on touch devices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19bd3d0ac832ab82e2fe4d5826747