### PR TITLE
Ajusta centrado en vistas iniciales en dispositivos móviles

### DIFF
--- a/css/descartes.css
+++ b/css/descartes.css
@@ -222,13 +222,30 @@
 
 /* === REGLAS PARA EL CENTRADO DE LA PÁGINA INICIAL === */
 .page-descartes-inicio #main-content {
+    display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding-top: 0;
+    min-height: 100dvh;
+    padding: clamp(96px, 20vh, 150px) 20px clamp(80px, 16vh, 130px);
+    gap: 32px;
+}
+
+.page-descartes-inicio #main-content .container {
+    width: min(100%, 600px);
 }
 
 .page-descartes-inicio .container h1 {
-    margin-bottom: 40px;
+    margin-bottom: 32px;
+}
+
+.page-descartes-inicio #inicio-descarte-section {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
 }
 
 .input-with-button {

--- a/css/inicio.css
+++ b/css/inicio.css
@@ -1,4 +1,18 @@
 /* --- Estilos de Página de Inicio (Dashboard) --- */
+.page-inicio #main-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 100dvh;
+    padding: clamp(96px, 20vh, 150px) 20px clamp(80px, 16vh, 130px);
+    gap: 32px;
+}
+
+.page-inicio #main-content .container {
+    width: min(100%, 720px);
+}
+
 .subtitle { text-align: center; margin-bottom: 40px; font-size: 1.1rem; color: var(--border-color); }
 .dashboard-grid { display: grid; grid-template-columns: 1fr; gap: 20px; }
 .card { background-color: var(--primary-color); padding: 40px 25px; border-radius: 10px; box-shadow: 0 4px 12px var(--shadow-color); text-decoration: none; color: rgba(255, 255, 255, 0.9); transition: transform 0.2s, box-shadow 0.2s; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
@@ -16,10 +30,7 @@
 
 /* --- Estilos solo para Escritorio --- */
 @media (min-width: 768px) {
-    #main-content {
-        /* Ajusta este valor para cambiar el espacio 
-           superior en la página de INICIO.
-        */
-        padding-top: 50px;
+    .page-inicio #main-content {
+        padding-top: clamp(120px, 18vh, 180px);
     }
 }

--- a/inicio.html
+++ b/inicio.html
@@ -24,7 +24,7 @@
 
     <link rel="icon" href="assets/icons/icon-192.png">
 </head>
-<body>
+<body class="page-inicio">
     <div id="navbar-placeholder"></div>
 
     <div id="loader" class="loader-wrapper">


### PR DESCRIPTION
## Summary
- centra la vista inicial de descartes en dispositivos móviles para mantener el botón y el título en posición central
- agrega una clase de página en inicio y ajusta sus estilos para evitar solapamientos con la barra de navegación en pantallas pequeñas

## Testing
- no se ejecutaron pruebas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_68e19ded43ac832ab0eb1b405cc12634