### PR TITLE
Ajusta layouts móviles para evitar solapamiento con teclado

### DIFF
--- a/css/descartes.css
+++ b/css/descartes.css
@@ -231,6 +231,19 @@
     gap: 32px;
 }
 
+@media (pointer: coarse) {
+    .page-descartes-inicio #main-content {
+        justify-content: flex-start;
+        min-height: auto;
+        padding: 4rem 1.5rem 3rem;
+        gap: 2.5rem;
+    }
+
+    .page-descartes-inicio #inicio-descarte-section {
+        align-items: stretch;
+    }
+}
+
 .page-descartes-inicio #main-content .container {
     width: min(100%, 600px);
 }

--- a/css/global.css
+++ b/css/global.css
@@ -484,6 +484,25 @@ body.nav-open .icon-menu { display: none; }
     text-align: center;
 }
 
+@media (pointer: coarse) {
+    .modal-overlay {
+        align-items: flex-start;
+        padding: 16px;
+        overflow-y: auto;
+    }
+
+    .modal-overlay.visible {
+        overflow-y: auto;
+    }
+
+    .modal-content {
+        margin-top: 16px;
+        margin-bottom: 16px;
+        max-height: calc(100dvh - 32px);
+        overflow-y: auto;
+    }
+}
+
 .modal-close-btn {
     position: absolute;
     top: 10px;

--- a/css/inicio.css
+++ b/css/inicio.css
@@ -9,6 +9,15 @@
     gap: 32px;
 }
 
+@media (pointer: coarse) {
+    .page-inicio #main-content {
+        justify-content: flex-start;
+        min-height: auto;
+        padding: 4rem 1.5rem 3rem;
+        gap: 2.5rem;
+    }
+}
+
 .page-inicio #main-content .container {
     width: min(100%, 720px);
 }

--- a/css/login.css
+++ b/css/login.css
@@ -169,12 +169,35 @@ body.dark-mode .login-container {
         height: auto;
         justify-content: flex-start;
         align-items: stretch;
-        padding-top: 40px;
-        padding-bottom: 40px;
+        padding: 3rem 1.5rem 3.5rem;
+        gap: 1.5rem;
     }
-    .page-main-title { font-size: 1.3rem; margin-bottom: 25px; }
-    .login-container { flex-direction: column; max-width: 400px; }
-    .login-info { text-align: center; align-items: center; padding: 20px; }
+    .page-main-title { font-size: 1.3rem; margin-bottom: 1.5rem; }
+    .login-container {
+        flex-direction: column;
+        align-items: stretch;
+        max-width: 420px;
+    }
+    .login-form-wrapper {
+        order: 1;
+        padding: 1.75rem 1.5rem 1.5rem;
+        flex: 1 1 auto;
+    }
+    #login-form {
+        justify-content: flex-start;
+        gap: 1.5rem;
+    }
+    .login-info {
+        order: 2;
+        text-align: center;
+        align-items: center;
+        justify-content: flex-start;
+        padding: 1.5rem;
+        flex: 0 0 auto;
+        max-height: 220px;
+        overflow-y: auto;
+        gap: 1rem;
+    }
     .login-logo { width: 120px; height: 120px; }
 }
 


### PR DESCRIPTION
## Summary
- ajusta la pantalla de inicio y el flujo de descartes para anclar el contenido en la parte superior en dispositivos táctiles
- reorganiza la vista de login en móviles para priorizar el formulario y mantener visibles los botones
- limita la altura de los modales y habilita desplazamiento vertical cuando se muestra el teclado en pantallas táctiles

## Testing
- Manual verification in mobile viewport using Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_68e1a264fc30832aa820be468e2e1b65