### PR TITLE
Adjust inicio layout spacing and width

### DIFF
--- a/css/inicio.css
+++ b/css/inicio.css
@@ -2,24 +2,25 @@
 .page-inicio #main-content {
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     min-height: 100dvh;
-    padding: clamp(96px, 20vh, 150px) 20px clamp(80px, 16vh, 130px);
-    gap: 32px;
+    padding: clamp(72px, 14vh, 120px) 24px clamp(64px, 12vh, 110px);
+    gap: clamp(28px, 5vh, 40px);
 }
 
 @media (pointer: coarse) {
     .page-inicio #main-content {
         justify-content: flex-start;
         min-height: auto;
-        padding: 4rem 1.5rem 3rem;
+        padding: 4rem 1.75rem 3rem;
         gap: 2.5rem;
     }
 }
 
 .page-inicio #main-content .container {
-    width: min(100%, 720px);
+    width: 100%;
+    max-width: 720px;
 }
 
 .subtitle { text-align: center; margin-bottom: 40px; font-size: 1.1rem; color: var(--border-color); }
@@ -40,6 +41,6 @@
 /* --- Estilos solo para Escritorio --- */
 @media (min-width: 768px) {
     .page-inicio #main-content {
-        padding-top: clamp(120px, 18vh, 180px);
+        padding-top: clamp(88px, 14vh, 140px);
     }
 }


### PR DESCRIPTION
## Summary
- reduce the top padding on the inicio dashboard so the welcome section sits closer to the navbar
- keep the layout anchored to the top on desktop while retaining generous spacing on touch devices
- restore the full card width by overriding the global container constraint for the dashboard grid

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1aa1de824832aa536d64ee136e993