### PR TITLE
Add Supabase-backed IP inventory management page

### DIFF
--- a/css/inventario.css
+++ b/css/inventario.css
@@ -1,0 +1,480 @@
+/* --- Inventario de IPs --- */
+
+.page-inventario main {
+  justify-content: center;
+}
+
+.inventory-container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.inventory-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.inventory-heading h1 {
+  margin-bottom: 8px;
+  text-align: left;
+}
+
+.page-description {
+  font-size: 1.05rem;
+  color: color-mix(in srgb, var(--text-color) 85%, transparent);
+  max-width: 680px;
+}
+
+.stats-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.stat-card {
+  background-color: var(--card-bg-color);
+  border-radius: 18px;
+  padding: 18px 22px;
+  box-shadow: 0 4px 14px var(--shadow-color);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 35%, transparent);
+}
+
+.stat-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text-color) 65%, transparent);
+}
+
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.filters-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  padding: 16px;
+  background-color: var(--card-bg-color);
+  border-radius: 24px;
+  box-shadow: 0 4px 12px var(--shadow-color);
+}
+
+.filters-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filters-group input,
+.filters-group select {
+  min-width: 220px;
+  height: 44px;
+  padding: 0 16px;
+  border-radius: var(--button-radius);
+  border: 1px solid var(--border-color);
+  background-color: var(--input-bg-color);
+  color: var(--input-text-color);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filters-group input:focus,
+.filters-group select:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color) 20%, transparent);
+  outline: none;
+}
+
+.filters-group select {
+  padding-right: 3rem;
+}
+
+.filters-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-left: auto;
+}
+
+.btn-export {
+  height: 44px;
+  padding: 0 20px;
+  border-radius: var(--button-radius);
+  border: none;
+  background-color: var(--success-color);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.btn-export:hover {
+  background-color: #1f7b34;
+}
+
+html.dark-mode .btn-export:hover {
+  background-color: #1a5d2a;
+}
+
+.table-wrapper {
+  background-color: var(--card-bg-color);
+  border-radius: 24px;
+  box-shadow: 0 8px 24px var(--shadow-color);
+  padding: 16px;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+#tabla-inventario {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 900px;
+}
+
+#tabla-inventario th,
+#tabla-inventario td {
+  padding: 14px 16px;
+  text-align: left;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-color) 35%, transparent);
+}
+
+#tabla-inventario thead {
+  position: sticky;
+  top: 0;
+  background-color: var(--card-bg-color);
+  z-index: 1;
+}
+
+#tabla-inventario th {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--text-color) 75%, transparent);
+  cursor: pointer;
+  position: relative;
+  user-select: none;
+}
+
+#tabla-inventario th.acciones {
+  cursor: default;
+}
+
+#tabla-inventario th[data-sort]::after {
+  content: '\25B4';
+  position: absolute;
+  right: 8px;
+  opacity: 0;
+  transform: translateY(-50%) rotate(0deg);
+  top: 50%;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  font-size: 0.65rem;
+}
+
+#tabla-inventario th[data-sort][data-direction="asc"]::after {
+  opacity: 0.9;
+  transform: translateY(-50%) rotate(0deg);
+}
+
+#tabla-inventario th[data-sort][data-direction="desc"]::after {
+  opacity: 0.9;
+  transform: translateY(-50%) rotate(180deg);
+}
+
+#tabla-inventario tbody tr {
+  transition: background-color 0.15s ease;
+}
+
+#tabla-inventario tbody tr:hover {
+  background-color: color-mix(in srgb, var(--primary-color) 12%, transparent);
+}
+
+.estado-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: var(--button-radius);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: capitalize;
+}
+
+.estado-pill--libre {
+  background-color: rgba(16, 185, 129, 0.2);
+  color: #047857;
+}
+
+.estado-pill--asignada {
+  background-color: rgba(248, 113, 113, 0.25);
+  color: #b91c1c;
+}
+
+.estado-pill--en_revision {
+  background-color: rgba(251, 191, 36, 0.25);
+  color: #92400e;
+}
+
+html.dark-mode .estado-pill--libre {
+  background-color: rgba(16, 185, 129, 0.28);
+  color: #34d399;
+}
+
+html.dark-mode .estado-pill--asignada {
+  background-color: rgba(248, 113, 113, 0.32);
+  color: #fca5a5;
+}
+
+html.dark-mode .estado-pill--en_revision {
+  background-color: rgba(251, 191, 36, 0.32);
+  color: #fcd34d;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.acciones-cell {
+  min-width: 220px;
+}
+
+.btn-action {
+  border: none;
+  background-color: color-mix(in srgb, var(--primary-color) 12%, transparent);
+  color: var(--primary-color);
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: var(--button-radius);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.btn-action:hover {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+.btn-action.btn-danger {
+  background-color: color-mix(in srgb, var(--error-color) 20%, transparent);
+  color: var(--error-color);
+}
+
+.btn-action.btn-danger:hover {
+  background-color: var(--error-color);
+  color: #fff;
+}
+
+.estado-quick-select {
+  height: 38px;
+  border-radius: var(--button-radius);
+  border: 1px solid var(--border-color);
+  background-color: var(--input-bg-color);
+  color: var(--input-text-color);
+  padding: 0 16px;
+}
+
+.estado-quick-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.empty-state {
+  margin-top: 18px;
+  text-align: center;
+  color: color-mix(in srgb, var(--text-color) 70%, transparent);
+}
+
+.row-estado-libre {
+  background-color: rgba(56, 178, 172, 0.18);
+}
+
+.row-estado-asignada {
+  background-color: rgba(239, 68, 68, 0.18);
+}
+
+.row-estado-en_revision {
+  background-color: rgba(234, 179, 8, 0.2);
+}
+
+html.dark-mode .row-estado-libre {
+  background-color: rgba(56, 178, 172, 0.28);
+}
+
+html.dark-mode .row-estado-asignada {
+  background-color: rgba(239, 68, 68, 0.28);
+}
+
+html.dark-mode .row-estado-en_revision {
+  background-color: rgba(234, 179, 8, 0.32);
+}
+
+html.dark-mode .filters-bar,
+html.dark-mode .table-wrapper,
+html.dark-mode .stat-card {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ip-input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-color: var(--input-bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 0 12px;
+  height: 44px;
+}
+
+.ip-prefix {
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text-color) 75%, transparent);
+}
+
+.ip-input-wrapper input {
+  border: none;
+  background: transparent;
+  width: 72px;
+  font-size: 1rem;
+  color: var(--input-text-color);
+}
+
+.ip-input-wrapper input:focus {
+  outline: none;
+}
+
+.available-ip-dropdown {
+  margin-top: 10px;
+  background-color: var(--card-bg-color);
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 35%, transparent);
+  box-shadow: 0 8px 16px var(--shadow-color);
+  padding: 8px;
+  display: grid;
+  gap: 6px;
+}
+
+.available-ip-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: var(--button-radius);
+  padding: 8px 12px;
+  background-color: color-mix(in srgb, var(--primary-color) 8%, transparent);
+  border: none;
+  cursor: pointer;
+  color: var(--text-color);
+  transition: background-color 0.2s ease;
+}
+
+.available-ip-item:hover,
+.available-ip-item:focus {
+  background-color: color-mix(in srgb, var(--primary-color) 18%, transparent);
+  outline: none;
+}
+
+.available-ip-empty {
+  text-align: center;
+  padding: 12px;
+  color: color-mix(in srgb, var(--text-color) 70%, transparent);
+  font-size: 0.95rem;
+}
+
+.modal-large {
+  max-width: 720px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group-full {
+  grid-column: 1 / -1;
+}
+
+.form-group textarea {
+  resize: vertical;
+}
+
+@media (max-width: 768px) {
+  .filters-group input,
+  .filters-group select {
+    min-width: unset;
+    width: 100%;
+  }
+
+  .filters-actions {
+    margin-left: 0;
+  }
+
+  #tabla-inventario {
+    min-width: 720px;
+  }
+}
+
+@media (max-width: 540px) {
+  .inventory-header {
+    align-items: stretch;
+  }
+
+  .inventory-heading h1 {
+    text-align: center;
+  }
+
+  .page-description {
+    text-align: center;
+  }
+
+  .inventory-header {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .filters-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filters-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .filters-actions button {
+    flex: 1 1 auto;
+  }
+}

--- a/inicio.html
+++ b/inicio.html
@@ -49,6 +49,10 @@
                     <h2>📊 Consultar</h2>
                     <p>Buscar, editar y ver todos los registros.</p>
                 </a>
+                <a href="inventario.html" class="card">
+                    <h2>Inventario de IPs</h2>
+                    <p>Administración de direcciones IPs.</p>
+                </a>
             </div>
         </div>
     </main>

--- a/inventario.html
+++ b/inventario.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inventario de IPs - Sistema de Registro</title>
+
+  <script>
+    (function () {
+      try {
+        const theme = localStorage.getItem('theme');
+        if (theme === 'dark') document.documentElement.classList.add('dark-mode');
+      } catch (e) {}
+    })();
+  </script>
+
+  <link rel="stylesheet" href="css/global.css" />
+  <link rel="stylesheet" href="css/inventario.css" />
+  <link rel="icon" href="assets/icons/icon-192.png" />
+</head>
+<body class="page-inventario">
+  <div id="navbar-placeholder"></div>
+
+  <div id="loader" class="loader-wrapper">
+    <div class="loader"></div>
+  </div>
+
+  <main id="main-content" style="display:none;">
+    <div class="inventory-container">
+      <header class="inventory-header">
+        <div class="inventory-heading">
+          <h1>Inventario de IPs</h1>
+          <p class="page-description">Control y registro de direcciones IP estáticas de equipos y dispositivos</p>
+        </div>
+        <button id="btn-nueva-ip" class="btn-principal" type="button">Nueva IP</button>
+      </header>
+
+      <section class="stats-overview" aria-live="polite">
+        <article class="stat-card">
+          <span class="stat-label">Total de IPs</span>
+          <span id="stat-total" class="stat-value">0</span>
+        </article>
+        <article class="stat-card">
+          <span class="stat-label">Libres</span>
+          <span id="stat-libres" class="stat-value">0</span>
+        </article>
+        <article class="stat-card">
+          <span class="stat-label">Asignadas</span>
+          <span id="stat-asignadas" class="stat-value">0</span>
+        </article>
+        <article class="stat-card">
+          <span class="stat-label">En revisión</span>
+          <span id="stat-revision" class="stat-value">0</span>
+        </article>
+      </section>
+
+      <section class="filters-bar" aria-label="Filtros del inventario">
+        <div class="filters-group">
+          <label class="sr-only" for="filter-search">Buscar</label>
+          <input
+            id="filter-search"
+            type="search"
+            placeholder="Buscar por dispositivo, RVE, IP o departamento"
+            autocomplete="off"
+          />
+        </div>
+        <div class="filters-group">
+          <label class="sr-only" for="filter-estado">Estado</label>
+          <select id="filter-estado">
+            <option value="">Todos los estados</option>
+            <option value="libre">Libre</option>
+            <option value="asignada">Asignada</option>
+            <option value="en_revision">En revisión</option>
+          </select>
+        </div>
+        <div class="filters-group">
+          <label class="sr-only" for="filter-departamento">Departamento</label>
+          <select id="filter-departamento">
+            <option value="">Todos los departamentos</option>
+          </select>
+        </div>
+        <div class="filters-actions">
+          <button id="btn-actualizar" class="btn-secondary" type="button">Actualizar</button>
+          <button id="btn-exportar" class="btn-export" type="button">Exportar a Excel</button>
+        </div>
+      </section>
+
+      <section class="table-wrapper">
+        <div class="table-container">
+          <table id="tabla-inventario">
+            <thead>
+              <tr>
+                <th scope="col" data-sort="dispositivo">Dispositivo</th>
+                <th scope="col" data-sort="tipo">Tipo</th>
+                <th scope="col" data-sort="departamento">Departamento</th>
+                <th scope="col" data-sort="ip">Dirección IP</th>
+                <th scope="col" data-sort="mascara">Máscara</th>
+                <th scope="col" data-sort="gateway">Gateway</th>
+                <th scope="col" data-sort="dns_1">DNS 1</th>
+                <th scope="col" data-sort="dns_2">DNS 2</th>
+                <th scope="col" data-sort="estado">Estado</th>
+                <th scope="col" class="acciones">Acciones</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <p id="empty-state" class="empty-state" hidden>No hay registros que coincidan con los filtros seleccionados.</p>
+      </section>
+    </div>
+  </main>
+
+  <div id="toast-notification" class="toast" role="status" aria-live="polite">
+    <span id="toast-message"></span>
+  </div>
+
+  <div id="modal-confirmacion" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="confirm-title" aria-describedby="confirm-message">
+    <div class="modal-content">
+      <button class="modal-close-btn" type="button" aria-label="Cerrar" data-close-confirm>&times;</button>
+      <h2 id="confirm-title">Confirmación</h2>
+      <p id="confirm-message">¿Deseas continuar?</p>
+      <div class="modal-buttons">
+        <button id="btn-confirmar-cancelar" class="btn-secondary" type="button">Cancelar</button>
+        <button id="btn-confirmar-aceptar" class="btn-danger" type="button">Aceptar</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="modal-ip" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="modal-ip-title">
+    <div class="modal-content modal-large">
+      <button class="modal-close-btn" type="button" aria-label="Cerrar" data-close-modal>&times;</button>
+      <h2 id="modal-ip-title">Nueva IP</h2>
+      <div class="modal-form-container">
+        <form id="form-ip">
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="input-dispositivo">Dispositivo</label>
+              <input id="input-dispositivo" name="dispositivo" type="text" placeholder="Ej. RVE-123-456" autocomplete="off" />
+            </div>
+            <div class="form-group">
+              <label for="input-tipo">Tipo</label>
+              <select id="input-tipo" name="tipo">
+                <option value="pc">PC</option>
+                <option value="router">Router</option>
+                <option value="impresora">Impresora</option>
+                <option value="switch">Switch</option>
+                <option value="otro">Otro</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="input-departamento">Departamento</label>
+              <input id="input-departamento" name="departamento" type="text" placeholder="Departamento" autocomplete="off" />
+            </div>
+            <div class="form-group ip-field-group">
+              <label for="input-ip-octeto">Dirección IP</label>
+              <div class="ip-input-wrapper">
+                <span class="ip-prefix" aria-hidden="true">10.106.113.</span>
+                <input id="input-ip-octeto" name="ip_octeto" type="number" min="0" max="254" inputmode="numeric" placeholder="0-254" />
+              </div>
+              <div id="available-ip-list" class="available-ip-dropdown" hidden></div>
+            </div>
+            <div class="form-group">
+              <label for="input-mascara">Máscara</label>
+              <input id="input-mascara" name="mascara" type="text" />
+            </div>
+            <div class="form-group">
+              <label for="input-gateway">Gateway</label>
+              <input id="input-gateway" name="gateway" type="text" />
+            </div>
+            <div class="form-group">
+              <label for="input-dns1">DNS 1</label>
+              <input id="input-dns1" name="dns_1" type="text" />
+            </div>
+            <div class="form-group">
+              <label for="input-dns2">DNS 2</label>
+              <input id="input-dns2" name="dns_2" type="text" />
+            </div>
+            <div class="form-group form-group-full">
+              <label for="input-notas">Notas</label>
+              <textarea id="input-notas" name="notas" rows="3" placeholder="Comentarios adicionales"></textarea>
+            </div>
+            <div class="form-group">
+              <label for="input-estado">Estado</label>
+              <select id="input-estado" name="estado">
+                <option value="libre">Libre</option>
+                <option value="asignada">Asignada</option>
+                <option value="en_revision">En revisión</option>
+              </select>
+            </div>
+          </div>
+          <div class="modal-buttons">
+            <button id="modal-cancel-btn" class="btn-secondary" type="button">Cancelar</button>
+            <button id="modal-submit-btn" class="btn-principal" type="submit">Guardar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="js/config.js"></script>
+  <script src="js/common.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script src="js/inventario.js"></script>
+</body>
+</html>

--- a/js/common.js
+++ b/js/common.js
@@ -20,6 +20,7 @@ const navbarHTML = `
                 <li class="nav-item"><a href="index.html" class="nav-link">📝 Registrar</a></li>
                 <li class="nav-item"><a href="descartes.html" class="nav-link">🗑️ Descartes</a></li>
                 <li class="nav-item"><a href="consultar.html" class="nav-link">📊 Consultar</a></li>
+                <li class="nav-item"><a href="inventario.html" class="nav-link">🖧 Inventario</a></li>
                 <li class="nav-separator"></li>
                 <li class="nav-item nav-item-controls">
                     <button id="theme-toggle" class="theme-btn nav-control-btn" title="Cambiar Tema">🌙</button>

--- a/js/inventario.js
+++ b/js/inventario.js
@@ -1,0 +1,763 @@
+// js/inventario.js
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const loader = document.getElementById('loader');
+  const mainContent = document.getElementById('main-content');
+
+  const searchInput = document.getElementById('filter-search');
+  const estadoSelect = document.getElementById('filter-estado');
+  const departamentoSelect = document.getElementById('filter-departamento');
+  const actualizarBtn = document.getElementById('btn-actualizar');
+  const exportarBtn = document.getElementById('btn-exportar');
+  const nuevaIpBtn = document.getElementById('btn-nueva-ip');
+
+  const tablaBody = document.querySelector('#tabla-inventario tbody');
+  const tableHeaders = document.querySelectorAll('#tabla-inventario thead th[data-sort]');
+  const emptyState = document.getElementById('empty-state');
+
+  const statTotal = document.getElementById('stat-total');
+  const statLibres = document.getElementById('stat-libres');
+  const statAsignadas = document.getElementById('stat-asignadas');
+  const statRevision = document.getElementById('stat-revision');
+
+  const toast = document.getElementById('toast-notification');
+  const toastMessage = document.getElementById('toast-message');
+
+  const modalOverlay = document.getElementById('modal-ip');
+  const modalTitle = document.getElementById('modal-ip-title');
+  const modalCloseBtns = modalOverlay?.querySelectorAll('[data-close-modal]');
+  const modalCancelBtn = document.getElementById('modal-cancel-btn');
+  const modalSubmitBtn = document.getElementById('modal-submit-btn');
+  const formIp = document.getElementById('form-ip');
+
+  const dispositivoInput = document.getElementById('input-dispositivo');
+  const tipoSelect = document.getElementById('input-tipo');
+  const departamentoInput = document.getElementById('input-departamento');
+  const ipOctetoInput = document.getElementById('input-ip-octeto');
+  const mascaraInput = document.getElementById('input-mascara');
+  const gatewayInput = document.getElementById('input-gateway');
+  const dns1Input = document.getElementById('input-dns1');
+  const dns2Input = document.getElementById('input-dns2');
+  const notasInput = document.getElementById('input-notas');
+  const estadoInput = document.getElementById('input-estado');
+  const availableIpList = document.getElementById('available-ip-list');
+
+  const confirmModal = document.getElementById('modal-confirmacion');
+  const confirmCloseBtn = confirmModal?.querySelector('[data-close-confirm]');
+  const confirmCancelBtn = document.getElementById('btn-confirmar-cancelar');
+
+  const IP_PREFIX = '10.106.113.';
+  const LAST_OCTET_MIN = 0;
+  const LAST_OCTET_MAX = 254;
+
+  let sessionUserId = null;
+  let allRecords = [];
+  let filteredRecords = [];
+  let currentSort = { column: 'ip', direction: 'asc' };
+  let isModalOpen = false;
+  let isEditing = false;
+  let editingId = null;
+  let selectedFreeRecordId = null;
+  let isSubmitting = false;
+  let toastTimeout;
+
+  const STATE_LABELS = {
+    libre: 'Libre',
+    asignada: 'Asignada',
+    en_revision: 'En revisión'
+  };
+
+  const DEFAULTS = {
+    mascara: '255.255.255.0',
+    gateway: '10.106.113.1',
+    dns1: '10.106.2.3',
+    dns2: '10.106.2.4'
+  };
+
+  async function ensureSession() {
+    const { data, error } = await supabaseClient.auth.getSession();
+    if (error) {
+      console.error('Error obteniendo la sesión', error);
+      return null;
+    }
+    return data?.session ?? null;
+  }
+
+  function showToast(message, type = 'success', duration = 3200) {
+    clearTimeout(toastTimeout);
+    if (!toast || !toastMessage) return;
+    toastMessage.textContent = message;
+    toast.className = `toast show ${type}`;
+    toastTimeout = setTimeout(() => {
+      toast.className = toast.className.replace('show', '');
+    }, duration);
+  }
+
+  function hideToast() {
+    if (!toast) return;
+    toast.className = toast.className.replace('show', '');
+  }
+
+  function toggleLoader(show) {
+    if (!loader || !mainContent) return;
+    loader.style.display = show ? 'flex' : 'none';
+    mainContent.style.display = show ? 'none' : 'block';
+  }
+
+  function resetModalState() {
+    isEditing = false;
+    editingId = null;
+    selectedFreeRecordId = null;
+    isModalOpen = false;
+    isSubmitting = false;
+  }
+
+  function closeModal() {
+    if (!modalOverlay) return;
+    modalOverlay.classList.remove('visible');
+    document.body.classList.remove('modal-open');
+    resetModalState();
+    formIp?.reset();
+    hideAvailableIpList();
+  }
+
+  function openModal({ mode = 'create', record = null } = {}) {
+    if (!modalOverlay) return;
+    isModalOpen = true;
+    modalOverlay.classList.add('visible');
+    document.body.classList.add('modal-open');
+
+    selectedFreeRecordId = null;
+    ipOctetoInput.disabled = mode === 'edit';
+    availableIpList.hidden = mode === 'edit';
+
+    if (mode === 'edit' && record) {
+      isEditing = true;
+      editingId = record.id;
+      modalTitle.textContent = 'Editar IP';
+
+      dispositivoInput.value = record.dispositivo ?? '';
+      tipoSelect.value = record.tipo ?? 'pc';
+      departamentoInput.value = record.departamento ?? '';
+      estadoInput.value = record.estado ?? 'libre';
+      notasInput.value = record.notas ?? '';
+      mascaraInput.value = record.mascara ?? DEFAULTS.mascara;
+      gatewayInput.value = record.gateway ?? DEFAULTS.gateway;
+      dns1Input.value = record.dns_1 ?? DEFAULTS.dns1;
+      dns2Input.value = record.dns_2 ?? DEFAULTS.dns2;
+
+      const lastOctet = extractLastOctet(record.ip);
+      ipOctetoInput.value = Number.isFinite(lastOctet) ? lastOctet : '';
+    } else {
+      isEditing = false;
+      editingId = null;
+      modalTitle.textContent = 'Nueva IP';
+      formIp.reset();
+      tipoSelect.value = 'pc';
+      estadoInput.value = 'libre';
+      mascaraInput.value = DEFAULTS.mascara;
+      gatewayInput.value = DEFAULTS.gateway;
+      dns1Input.value = DEFAULTS.dns1;
+      dns2Input.value = DEFAULTS.dns2;
+      ipOctetoInput.value = '';
+      notasInput.value = '';
+      dispositivoInput.value = '';
+      departamentoInput.value = '';
+      hideAvailableIpList();
+    }
+
+    updateDepartmentRequirement();
+  }
+
+  function extractLastOctet(ip = '') {
+    if (!ip) return null;
+    const parts = ip.split('.');
+    const last = Number(parts[parts.length - 1]);
+    return Number.isFinite(last) ? last : null;
+  }
+
+  function populateAvailableIpList() {
+    if (!availableIpList) return;
+    const libres = allRecords.filter((record) => record.estado === 'libre');
+    availableIpList.innerHTML = '';
+
+    if (!libres.length) {
+      availableIpList.appendChild(createElement('div', 'available-ip-empty', 'No hay IPs libres registradas.'));
+    } else {
+      libres.forEach((record) => {
+        const lastOctet = extractLastOctet(record.ip);
+        const button = createElement('button', 'available-ip-item');
+        button.type = 'button';
+        button.dataset.id = record.id;
+        button.dataset.octet = lastOctet ?? '';
+
+        const ipLabel = createElement('span', null, record.ip || '');
+        const deptLabel = createElement('span', null, record.departamento || 'Sin depto.');
+        button.append(ipLabel, deptLabel);
+        button.addEventListener('click', () => {
+          ipOctetoInput.value = button.dataset.octet ?? '';
+          estadoInput.value = 'asignada';
+          selectedFreeRecordId = record.id;
+          showToast(`IP ${record.ip} seleccionada para asignación.`, 'success', 2400);
+          hideAvailableIpList();
+        });
+        availableIpList.appendChild(button);
+      });
+    }
+
+    availableIpList.hidden = false;
+  }
+
+  function hideAvailableIpList() {
+    if (!availableIpList) return;
+    availableIpList.hidden = true;
+  }
+
+  function createElement(tag, className, textContent) {
+    const el = document.createElement(tag);
+    if (className) el.className = className;
+    if (typeof textContent === 'string') el.textContent = textContent;
+    return el;
+  }
+
+  function updateDepartmentRequirement() {
+    if (!estadoInput || !departamentoInput) return;
+    const isLibre = estadoInput.value === 'libre';
+    if (isLibre) {
+      departamentoInput.removeAttribute('required');
+    } else {
+      departamentoInput.setAttribute('required', 'true');
+    }
+  }
+
+  function applyRowStateClass(row, estado) {
+    row.classList.remove('row-estado-libre', 'row-estado-asignada', 'row-estado-en_revision');
+    if (estado === 'libre') row.classList.add('row-estado-libre');
+    else if (estado === 'asignada') row.classList.add('row-estado-asignada');
+    else if (estado === 'en_revision') row.classList.add('row-estado-en_revision');
+  }
+
+  function applyFilters() {
+    const searchTerm = (searchInput?.value || '').trim().toLowerCase();
+    const estadoValue = estadoSelect?.value || '';
+    const departamentoValue = departamentoSelect?.value || '';
+
+    filteredRecords = allRecords.filter((record) => {
+      const matchesSearch = !searchTerm
+        || (record.dispositivo || '').toLowerCase().includes(searchTerm)
+        || (record.departamento || '').toLowerCase().includes(searchTerm)
+        || (record.ip || '').toLowerCase().includes(searchTerm);
+
+      const matchesEstado = !estadoValue || record.estado === estadoValue;
+      const matchesDepartamento = !departamentoValue || (record.departamento || '') === departamentoValue;
+
+      return matchesSearch && matchesEstado && matchesDepartamento;
+    });
+
+    filteredRecords = sortRecords(filteredRecords);
+    renderTable(filteredRecords);
+    updateCounters();
+  }
+
+  function sortRecords(records) {
+    const { column, direction } = currentSort;
+    const dir = direction === 'asc' ? 1 : -1;
+    return [...records].sort((a, b) => {
+      const valueA = getComparableValue(a, column);
+      const valueB = getComparableValue(b, column);
+
+      if (valueA < valueB) return -1 * dir;
+      if (valueA > valueB) return 1 * dir;
+      return 0;
+    });
+  }
+
+  function getComparableValue(record, column) {
+    const value = record?.[column];
+    if (column === 'ip') {
+      return value ? value.split('.').map(Number).reduce((acc, part) => acc * 256 + part, 0) : -1;
+    }
+    if (typeof value === 'string') {
+      return value.toLowerCase();
+    }
+    if (typeof value === 'number') {
+      return value;
+    }
+    return value ?? '';
+  }
+
+  function renderTable(records) {
+    if (!tablaBody) return;
+    tablaBody.innerHTML = '';
+
+    if (!records.length) {
+      emptyState.hidden = false;
+      return;
+    }
+
+    emptyState.hidden = true;
+
+    records.forEach((record) => {
+      const estadoValue = record.estado || 'libre';
+      const tr = document.createElement('tr');
+      tr.dataset.id = record.id;
+      applyRowStateClass(tr, estadoValue);
+
+      const dispositivoTd = createElement('td', null, record.dispositivo || '—');
+      const tipoTd = createElement('td', null, (record.tipo || 'pc').toUpperCase());
+      const departamentoTd = createElement('td', null, record.departamento || '—');
+      const ipTd = createElement('td', null, record.ip || '—');
+      const mascaraTd = createElement('td', null, record.mascara || '—');
+      const gatewayTd = createElement('td', null, record.gateway || '—');
+      const dns1Td = createElement('td', null, record.dns_1 || '—');
+      const dns2Td = createElement('td', null, record.dns_2 || '—');
+
+      const estadoTd = document.createElement('td');
+      const estadoPill = createElement('span', `estado-pill estado-pill--${estadoValue}`);
+      estadoPill.textContent = STATE_LABELS[estadoValue] || estadoValue;
+      estadoTd.appendChild(estadoPill);
+
+      const accionesTd = document.createElement('td');
+      accionesTd.classList.add('acciones-cell');
+      const actionWrapper = createElement('div', 'action-buttons');
+
+      const editarBtn = createElement('button', 'btn-action', 'Editar');
+      editarBtn.type = 'button';
+      editarBtn.dataset.action = 'edit';
+      editarBtn.dataset.id = record.id;
+      editarBtn.title = 'Editar';
+
+      const eliminarBtn = createElement('button', 'btn-action btn-danger', 'Eliminar');
+      eliminarBtn.type = 'button';
+      eliminarBtn.dataset.action = 'delete';
+      eliminarBtn.dataset.id = record.id;
+      eliminarBtn.title = 'Eliminar';
+
+      const estadoSelectQuick = document.createElement('select');
+      estadoSelectQuick.className = 'estado-quick-select';
+      estadoSelectQuick.dataset.id = record.id;
+      estadoSelectQuick.title = 'Estado';
+      ['libre', 'asignada', 'en_revision'].forEach((estado) => {
+        const option = document.createElement('option');
+        option.value = estado;
+        option.textContent = STATE_LABELS[estado];
+        if (estado === estadoValue) option.selected = true;
+        estadoSelectQuick.appendChild(option);
+      });
+
+      actionWrapper.append(editarBtn, eliminarBtn, estadoSelectQuick);
+      accionesTd.appendChild(actionWrapper);
+
+      tr.append(
+        dispositivoTd,
+        tipoTd,
+        departamentoTd,
+        ipTd,
+        mascaraTd,
+        gatewayTd,
+        dns1Td,
+        dns2Td,
+        estadoTd,
+        accionesTd
+      );
+
+      tablaBody.appendChild(tr);
+    });
+
+    updateSortIndicators();
+  }
+
+  function updateCounters() {
+    const total = allRecords.length;
+    const libres = allRecords.filter((r) => r.estado === 'libre').length;
+    const asignadas = allRecords.filter((r) => r.estado === 'asignada').length;
+    const revision = allRecords.filter((r) => r.estado === 'en_revision').length;
+
+    statTotal.textContent = total;
+    statLibres.textContent = libres;
+    statAsignadas.textContent = asignadas;
+    statRevision.textContent = revision;
+  }
+
+  function updateSortIndicators() {
+    tableHeaders.forEach((th) => {
+      const sortKey = th.dataset.sort;
+      if (sortKey === currentSort.column) {
+        th.setAttribute('data-direction', currentSort.direction);
+      } else {
+        th.removeAttribute('data-direction');
+      }
+    });
+  }
+
+  function populateDepartmentOptions() {
+    if (!departamentoSelect) return;
+    const selected = departamentoSelect.value;
+    const uniqueDepartments = Array.from(
+      new Set(
+        allRecords
+          .map((record) => record.departamento)
+          .filter((dept) => typeof dept === 'string' && dept.trim() !== '')
+      )
+    ).sort((a, b) => a.localeCompare(b));
+
+    departamentoSelect.innerHTML = '<option value="">Todos los departamentos</option>';
+    uniqueDepartments.forEach((dept) => {
+      const option = document.createElement('option');
+      option.value = dept;
+      option.textContent = dept;
+      departamentoSelect.appendChild(option);
+    });
+
+    if (selected && uniqueDepartments.includes(selected)) {
+      departamentoSelect.value = selected;
+    }
+  }
+
+  async function fetchRecords({ showLoader = false } = {}) {
+    if (showLoader) toggleLoader(true);
+    try {
+      const { data, error } = await supabaseClient
+        .from('inventario_ip')
+        .select('*')
+        .order('ip', { ascending: true });
+
+      if (error) throw error;
+
+      allRecords = Array.isArray(data) ? data : [];
+      populateDepartmentOptions();
+      applyFilters();
+    } catch (error) {
+      console.error('Error al obtener inventario', error);
+      showToast('Error al cargar el inventario de IPs.', 'error');
+    } finally {
+      if (showLoader) toggleLoader(false);
+    }
+  }
+
+  function validateIp(octetValue) {
+    if (octetValue === '' || octetValue === null || octetValue === undefined) {
+      return { valid: false, message: 'Debes indicar el último octeto de la IP.' };
+    }
+    const octet = Number(octetValue);
+    if (!Number.isInteger(octet) || octet < LAST_OCTET_MIN || octet > LAST_OCTET_MAX) {
+      return { valid: false, message: 'El último octeto debe estar entre 0 y 254.' };
+    }
+    return { valid: true, value: `${IP_PREFIX}${octet}` };
+  }
+
+  function buildPayloadFromForm() {
+    const dispositivo = dispositivoInput.value.trim();
+    const tipo = tipoSelect.value;
+    const departamento = departamentoInput.value.trim();
+    const estado = estadoInput.value;
+    const notas = notasInput.value.trim();
+
+    const mascara = mascaraInput.value.trim() || DEFAULTS.mascara;
+    const gateway = gatewayInput.value.trim() || DEFAULTS.gateway;
+    const dns_1 = dns1Input.value.trim() || DEFAULTS.dns1;
+    const dns_2 = dns2Input.value.trim() || DEFAULTS.dns2;
+
+    const octetValidation = validateIp(ipOctetoInput.value);
+    if (!octetValidation.valid) {
+      throw new Error(octetValidation.message);
+    }
+    const ip = octetValidation.value;
+
+    if (estado === 'asignada') {
+      if (!dispositivo) throw new Error('Para asignar una IP debes indicar el dispositivo.');
+      if (!departamento) throw new Error('Para asignar una IP debes indicar el departamento.');
+    }
+
+    return {
+      ip,
+      dispositivo: dispositivo || null,
+      tipo: tipo || 'pc',
+      departamento: departamento || null,
+      estado,
+      notas: notas || null,
+      mascara,
+      gateway,
+      dns_1,
+      dns_2
+    };
+  }
+
+  async function handleFormSubmit(event) {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    try {
+      const payload = buildPayloadFromForm();
+      isSubmitting = true;
+      modalSubmitBtn.disabled = true;
+      modalCancelBtn.disabled = true;
+
+      if (isEditing && editingId) {
+        await updateRecord(editingId, payload);
+        showToast('Registro actualizado correctamente.');
+      } else if (selectedFreeRecordId) {
+        await updateRecord(selectedFreeRecordId, { ...payload, estado: 'asignada' });
+        showToast('IP libre asignada correctamente.');
+      } else {
+        await createRecord(payload);
+        showToast('IP creada correctamente.');
+      }
+
+      closeModal();
+      await fetchRecords();
+    } catch (error) {
+      const message = error?.message || 'No se pudo guardar el registro.';
+      showToast(message, 'error', 4200);
+      console.error('Error guardando IP', error);
+    } finally {
+      isSubmitting = false;
+      modalSubmitBtn.disabled = false;
+      modalCancelBtn.disabled = false;
+    }
+  }
+
+  async function createRecord(payload) {
+    const insertPayload = {
+      ...payload,
+      asignado_por: sessionUserId
+    };
+
+    const { error } = await supabaseClient
+      .from('inventario_ip')
+      .insert([insertPayload]);
+
+    if (error) {
+      if (error.code === '23505') {
+        throw new Error('Esa IP ya está registrada.');
+      }
+      throw error;
+    }
+  }
+
+  async function updateRecord(id, payload) {
+    const { error } = await supabaseClient
+      .from('inventario_ip')
+      .update(payload)
+      .eq('id', id);
+
+    if (error) {
+      if (error.code === '23505') {
+        throw new Error('Esa IP ya está registrada.');
+      }
+      throw error;
+    }
+  }
+
+  async function deleteRecord(id) {
+    const { error } = await supabaseClient
+      .from('inventario_ip')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      if (error.code === '42501') {
+        throw new Error('No tienes permisos para eliminar esta IP.');
+      }
+      throw error;
+    }
+  }
+
+  async function handleDelete(id) {
+    const record = allRecords.find((item) => item.id === id);
+    if (!record) return;
+
+    const confirmed = await window.showConfirmationModal(
+      'Eliminar IP',
+      `¿Deseas eliminar la IP ${record.ip}?`
+    );
+
+    if (!confirmed) return;
+
+    try {
+      await deleteRecord(id);
+      showToast('IP eliminada correctamente.');
+      await fetchRecords();
+    } catch (error) {
+      const message = error?.message || 'No se pudo eliminar la IP.';
+      showToast(message, 'error', 4200);
+      console.error('Error eliminando IP', error);
+    }
+  }
+
+  async function handleQuickEstadoChange(selectEl) {
+    const id = selectEl.dataset.id;
+    const newEstado = selectEl.value;
+    const record = allRecords.find((item) => item.id === id);
+    if (!record) return;
+
+    try {
+      selectEl.disabled = true;
+
+      if (newEstado === 'libre') {
+        await updateRecord(id, {
+          dispositivo: null,
+          tipo: 'pc',
+          departamento: null,
+          notas: null,
+          estado: 'libre'
+        });
+        showToast(`La IP ${record.ip} ahora está libre.`);
+      } else if (newEstado === 'asignada') {
+        if (!record.dispositivo || !record.departamento) {
+          showToast('Completa los datos obligatorios antes de asignar esta IP.', 'error', 4200);
+          selectEl.value = record.estado;
+          openModal({ mode: 'edit', record });
+          return;
+        }
+        await updateRecord(id, { estado: 'asignada' });
+        showToast(`La IP ${record.ip} fue marcada como asignada.`);
+      } else if (newEstado === 'en_revision') {
+        await updateRecord(id, { estado: 'en_revision' });
+        showToast(`La IP ${record.ip} se marcó en revisión.`);
+      }
+
+      await fetchRecords();
+    } catch (error) {
+      showToast('No se pudo actualizar el estado.', 'error', 4200);
+      console.error('Error cambiando estado', error);
+      selectEl.value = record.estado;
+    } finally {
+      selectEl.disabled = false;
+    }
+  }
+
+  function exportToExcel() {
+    if (!filteredRecords.length) {
+      showToast('No hay registros para exportar.', 'error', 3200);
+      return;
+    }
+
+    const exportRows = filteredRecords.map((record) => ({
+      'Dispositivo': record.dispositivo || '',
+      'Tipo': (record.tipo || 'pc').toUpperCase(),
+      'Departamento': record.departamento || '',
+      'Dirección IP': record.ip || '',
+      'Máscara': record.mascara || '',
+      'Gateway': record.gateway || '',
+      'DNS 1': record.dns_1 || '',
+      'DNS 2': record.dns_2 || '',
+      'Estado': STATE_LABELS[record.estado] || record.estado
+    }));
+
+    const worksheet = XLSX.utils.json_to_sheet(exportRows, {
+      header: [
+        'Dispositivo',
+        'Tipo',
+        'Departamento',
+        'Dirección IP',
+        'Máscara',
+        'Gateway',
+        'DNS 1',
+        'DNS 2',
+        'Estado'
+      ]
+    });
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Inventario IPs');
+    const fileName = `Inventario_IPs_${new Date().toISOString().split('T')[0]}.xlsx`;
+    XLSX.writeFile(workbook, fileName);
+    showToast('Exportación completada.');
+  }
+
+  function attachEventListeners() {
+    searchInput?.addEventListener('input', () => applyFilters());
+    estadoSelect?.addEventListener('change', () => applyFilters());
+    departamentoSelect?.addEventListener('change', () => applyFilters());
+    actualizarBtn?.addEventListener('click', () => fetchRecords());
+    exportarBtn?.addEventListener('click', exportToExcel);
+    nuevaIpBtn?.addEventListener('click', () => openModal({ mode: 'create' }));
+
+    modalCloseBtns?.forEach((btn) => btn.addEventListener('click', closeModal));
+    modalCancelBtn?.addEventListener('click', closeModal);
+    formIp?.addEventListener('submit', handleFormSubmit);
+    estadoInput?.addEventListener('change', updateDepartmentRequirement);
+
+    ipOctetoInput?.addEventListener('focus', () => {
+      if (!isEditing) {
+        populateAvailableIpList();
+      }
+    });
+
+    ipOctetoInput?.addEventListener('input', () => {
+      selectedFreeRecordId = null;
+      if (Number(ipOctetoInput.value) > LAST_OCTET_MAX) {
+        ipOctetoInput.value = LAST_OCTET_MAX;
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!availableIpList || availableIpList.hidden) return;
+      const isInside = availableIpList.contains(event.target) || event.target === ipOctetoInput;
+      if (!isInside) {
+        hideAvailableIpList();
+      }
+    });
+
+    tablaBody?.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const action = target.dataset.action;
+      if (!action) return;
+
+      const id = target.dataset.id;
+      const record = allRecords.find((item) => item.id === id);
+      if (!record) return;
+
+      if (action === 'edit') {
+        openModal({ mode: 'edit', record });
+      } else if (action === 'delete') {
+        handleDelete(id);
+      }
+    });
+
+    tablaBody?.addEventListener('change', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLSelectElement)) return;
+      if (target.matches('.estado-quick-select')) {
+        handleQuickEstadoChange(target);
+      }
+    });
+
+    tableHeaders.forEach((th) => {
+      th.addEventListener('click', () => {
+        const column = th.dataset.sort;
+        if (!column) return;
+        if (currentSort.column === column) {
+          currentSort.direction = currentSort.direction === 'asc' ? 'desc' : 'asc';
+        } else {
+          currentSort.column = column;
+          currentSort.direction = 'asc';
+        }
+        applyFilters();
+      });
+    });
+
+    confirmCloseBtn?.addEventListener('click', () => {
+      confirmCancelBtn?.click();
+    });
+
+    modalOverlay?.addEventListener('click', (event) => {
+      if (event.target === modalOverlay) {
+        closeModal();
+      }
+    });
+  }
+
+  const session = await ensureSession();
+  if (!session) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  sessionUserId = session.user?.id || null;
+  toggleLoader(true);
+  attachEventListeners();
+  await fetchRecords({ showLoader: false });
+  toggleLoader(false);
+});


### PR DESCRIPTION
## Summary
- add the new inventario.html view with counters, filters, modal scaffolding, and shared confirmation/toast containers
- implement dedicated styles and JavaScript to manage Supabase CRUD, filtering, quick state changes, and Excel export for the IP inventory
- surface the inventory entry point through the global navigation and the home dashboard card

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1bc89aaa8832ab9dedab548f44223