### PR TITLE
Improve inventory action accessibility and expand home dashboard layout

### DIFF
--- a/css/inicio.css
+++ b/css/inicio.css
@@ -3,7 +3,7 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    align-items: center;
+    align-items: stretch;
     min-height: 100dvh;
     padding: clamp(72px, 14vh, 120px) 24px clamp(64px, 12vh, 110px);
     gap: clamp(28px, 5vh, 40px);
@@ -12,6 +12,7 @@
 @media (pointer: coarse) {
     .page-inicio #main-content {
         justify-content: flex-start;
+        align-items: stretch;
         min-height: auto;
         padding: 4rem 1.75rem 3rem;
         gap: 2.5rem;
@@ -20,11 +21,11 @@
 
 .page-inicio #main-content .container {
     width: 100%;
-    max-width: 720px;
+    max-width: none;
 }
 
 .subtitle { text-align: center; margin-bottom: 40px; font-size: 1.1rem; color: var(--border-color); }
-.dashboard-grid { display: grid; grid-template-columns: 1fr; gap: 20px; }
+.dashboard-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: clamp(20px, 3vw, 32px); }
 .card { background-color: var(--primary-color); padding: 40px 25px; border-radius: 10px; box-shadow: 0 4px 12px var(--shadow-color); text-decoration: none; color: rgba(255, 255, 255, 0.9); transition: transform 0.2s, box-shadow 0.2s; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
 .card:hover { transform: translateY(-5px) scale(1.02); box-shadow: 0 8px 20px var(--shadow-color); }
 .card h2 { color: #FFFFFF; margin-top: 0; margin-bottom: 10px; font-size: 1.6rem; border-bottom: none; padding-bottom: 0; }
@@ -35,7 +36,8 @@
 /* --- Responsivo --- */
 @media (min-width: 768px) {
     .container { max-width: 1000px; }
-    .dashboard-grid { grid-template-columns: repeat(3, 1fr); }
+    .page-inicio #main-content .container { max-width: none; }
+    .dashboard-grid { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
 }
 
 /* --- Estilos solo para Escritorio --- */

--- a/css/inventario.css
+++ b/css/inventario.css
@@ -298,24 +298,26 @@ html.dark-mode .btn-export:hover {
 .action-buttons {
   display: flex;
   gap: 10px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
+  row-gap: 12px;
 }
 
 .acciones-cell {
-  min-width: 260px;
-  width: 1%;
+  min-width: 320px;
+  width: auto;
 }
 
 .btn-action {
   border: none;
-  background-color: color-mix(in srgb, var(--primary-color) 12%, transparent);
-  color: var(--primary-color);
+  background-color: color-mix(in srgb, var(--primary-color) 35%, var(--card-bg-color));
+  color: color-mix(in srgb, #ffffff 92%, var(--primary-color));
   font-weight: 600;
   padding: 8px 14px;
   border-radius: var(--button-radius);
   cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary-color) 45%, transparent);
 }
 
 .btn-action:hover {
@@ -324,13 +326,39 @@ html.dark-mode .btn-export:hover {
 }
 
 .btn-action.btn-danger {
-  background-color: color-mix(in srgb, var(--error-color) 20%, transparent);
-  color: var(--error-color);
+  background-color: color-mix(in srgb, var(--error-color) 38%, var(--card-bg-color));
+  color: color-mix(in srgb, #ffffff 92%, var(--error-color));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--error-color) 50%, transparent);
 }
 
 .btn-action.btn-danger:hover {
   background-color: var(--error-color);
   color: #fff;
+}
+
+.action-buttons .estado-quick-select {
+  flex: 1 1 100%;
+  min-width: 200px;
+}
+
+html.dark-mode .btn-action {
+  background-color: color-mix(in srgb, var(--primary-color) 60%, var(--card-bg-color));
+  color: #fff;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary-color) 65%, transparent);
+}
+
+html.dark-mode .btn-action:hover {
+  background-color: color-mix(in srgb, var(--primary-color) 80%, #000);
+}
+
+html.dark-mode .btn-action.btn-danger {
+  background-color: color-mix(in srgb, var(--error-color) 65%, var(--card-bg-color));
+  color: #fff;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--error-color) 70%, transparent);
+}
+
+html.dark-mode .btn-action.btn-danger:hover {
+  background-color: color-mix(in srgb, var(--error-color) 82%, #000);
 }
 
 .estado-quick-select {


### PR DESCRIPTION
## Summary
- raise contrast for inventory action buttons in both themes and add dark mode specific styling
- let action controls wrap so the Estado selector remains fully visible on narrow table widths
- expand the home dashboard container and grid so cards span the available width on desktop

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1d32ab958832a80ee7a7fb027c8a3