### PR TITLE
Ajustar estilo y limpieza de campos en inventario de IPs

### DIFF
--- a/css/inventario.css
+++ b/css/inventario.css
@@ -296,22 +296,24 @@ html.dark-mode .btn-export:hover {
 }
 
 .action-buttons {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  column-gap: 10px;
   row-gap: 12px;
+  align-items: center;
+  justify-content: flex-start;
+  justify-items: start;
 }
 
 .acciones-cell {
-  min-width: 320px;
+  min-width: 260px;
   width: auto;
 }
 
 .btn-action {
   border: none;
   background-color: color-mix(in srgb, var(--primary-color) 35%, var(--card-bg-color));
-  color: color-mix(in srgb, #ffffff 92%, var(--primary-color));
+  color: color-mix(in srgb, #111111 88%, var(--primary-color));
   font-weight: 600;
   padding: 8px 14px;
   border-radius: var(--button-radius);
@@ -327,7 +329,7 @@ html.dark-mode .btn-export:hover {
 
 .btn-action.btn-danger {
   background-color: color-mix(in srgb, var(--error-color) 38%, var(--card-bg-color));
-  color: color-mix(in srgb, #ffffff 92%, var(--error-color));
+  color: color-mix(in srgb, #111111 88%, var(--error-color));
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--error-color) 50%, transparent);
 }
 
@@ -337,8 +339,9 @@ html.dark-mode .btn-export:hover {
 }
 
 .action-buttons .estado-quick-select {
-  flex: 1 1 100%;
-  min-width: 200px;
+  grid-column: 1 / -1;
+  width: 100%;
+  min-width: 0;
 }
 
 html.dark-mode .btn-action {
@@ -373,6 +376,16 @@ html.dark-mode .btn-action.btn-danger:hover {
 .estado-quick-select:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .action-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .action-buttons .estado-quick-select {
+    grid-column: 1;
+  }
 }
 
 .empty-state {

--- a/inicio.html
+++ b/inicio.html
@@ -50,7 +50,7 @@
                     <p>Buscar, editar y ver todos los registros.</p>
                 </a>
                 <a href="inventario.html" class="card">
-                    <h2>Inventario de IPs</h2>
+                    <h2>🖧 Inventario de IPs</h2>
                     <p>Administración de direcciones IPs.</p>
                 </a>
             </div>

--- a/js/inventario.js
+++ b/js/inventario.js
@@ -74,6 +74,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     dns2: '10.106.2.4'
   };
 
+  const CLEAR_ON_FREE_FIELDS = [
+    'dispositivo',
+    'tipo',
+    'departamento',
+    'notas',
+    'asignado_por'
+  ];
+
   async function ensureSession() {
     const { data, error } = await supabaseClient.auth.getSession();
     if (error) {
@@ -642,13 +650,20 @@ document.addEventListener('DOMContentLoaded', async () => {
       selectEl.disabled = true;
 
       if (newEstado === 'libre') {
-        await updateRecord(id, {
-          dispositivo: null,
-          tipo: 'pc',
-          departamento: null,
-          notas: null,
-          estado: 'libre'
+        const clearPayload = { estado: 'libre' };
+        CLEAR_ON_FREE_FIELDS.forEach((field) => {
+          if (field in record) {
+            clearPayload[field] = null;
+          }
         });
+
+        Object.keys(record).forEach((key) => {
+          if (key.startsWith('asignado_')) {
+            clearPayload[key] = null;
+          }
+        });
+
+        await updateRecord(id, clearPayload);
         showToast(`La IP ${record.ip} ahora está libre.`);
       } else if (newEstado === 'asignada') {
         if (!record.dispositivo || !record.departamento) {


### PR DESCRIPTION
## Summary
- Añadir un icono a la tarjeta de Inventario de IPs en la página de inicio para mantener la consistencia visual.
- Ajustar estilos de los botones de acción y del selector de estado en el inventario para mejorar el contraste y equilibrar el ancho de la columna.
- Actualizar la lógica del cambio rápido a estado libre para limpiar automáticamente los campos asociados al dispositivo.

## Testing
- No se ejecutaron pruebas (no aplicable).


------
https://chatgpt.com/codex/tasks/task_e_68e1d81b93cc832ab3e333f284d5e5c4