### PR TITLE
Permitir limpiar y personalizar el tipo de dispositivo

### DIFF
--- a/inventario.html
+++ b/inventario.html
@@ -136,12 +136,21 @@
             <div class="form-group">
               <label for="input-tipo">Tipo</label>
               <select id="input-tipo" name="tipo">
+                <option value="">Selecciona un tipo</option>
                 <option value="pc">PC</option>
                 <option value="router">Router</option>
                 <option value="impresora">Impresora</option>
                 <option value="switch">Switch</option>
                 <option value="otro">Otro</option>
               </select>
+              <input
+                id="input-tipo-custom"
+                class="tipo-custom-input"
+                type="text"
+                placeholder="Especifica el tipo"
+                autocomplete="off"
+                hidden
+              />
             </div>
             <div class="form-group">
               <label for="input-departamento">Departamento</label>


### PR DESCRIPTION
## Summary
- agrega una opción vacía y un campo de texto para que el tipo del dispositivo pueda quedar limpio o aceptar valores personalizados
- actualiza la lógica del inventario para mostrar el campo personalizado, almacenar el texto ingresado y limpiar el tipo cuando la IP queda libre

## Testing
- No se ejecutaron pruebas (no disponibles)


------
https://chatgpt.com/codex/tasks/task_e_68e1e5255e90832a930c6a41a9e341ec