### PR TITLE
Ajusta borde redondeado del botón Inventario en la barra de navegación

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -383,7 +383,8 @@ body.nav-open .nav-links {
         border-bottom-left-radius: 50px;
     }
 
-    .nav-links .nav-item:nth-child(4) .nav-link.active {
+    /* Ajuste: el quinto elemento (Inventario) es ahora el último botón visible */
+    .nav-links .nav-item:nth-child(5) .nav-link.active {
         border-top-right-radius: 50px;
         border-bottom-right-radius: 50px;
     }


### PR DESCRIPTION
## Summary
- actualiza el selector CSS que aplica el borde redondeado derecho para que apunte al botón Inventario
- añade un comentario aclaratorio que documenta el motivo del ajuste

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e271625cdc832aa1d227a7746aa78a