### PR TITLE
Use SVG icons for theme toggle and logout

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -299,6 +299,11 @@ body.nav-open .nav-links {
     place-items: center;
     padding: 0;
     line-height: 1;
+    color: var(--text-color);
+}
+
+html.dark-mode .nav-control-btn {
+    color: #F9FAFB;
 }
 
 .nav-control-btn:hover {
@@ -306,7 +311,6 @@ body.nav-open .nav-links {
 }
 
 #theme-toggle.theme-btn {
-    font-size: 1.5rem;
     width: 40px;
     height: 40px;
     border-radius: 50%;
@@ -325,6 +329,14 @@ body.nav-open .nav-links {
     border-radius: 50%;
     border: 1px solid var(--border-color);
     background-color: var(--card-bg-color);
+}
+
+.theme-btn {
+    color: var(--text-color);
+}
+
+html.dark-mode .theme-btn {
+    color: #F9FAFB;
 }
 
 @media (min-width: 768px) {
@@ -436,10 +448,25 @@ body.nav-open .nav-links {
 }
 
 /* --- 6. Iconos Personalizados --- */
-.nav-control-btn img {
+.icon {
     display: block;
     width: 26px;
     height: 26px;
+    background-color: currentColor;
+    mask: var(--icon-url) center/contain no-repeat;
+    -webkit-mask: var(--icon-url) center/contain no-repeat;
+}
+
+.icon-theme-dark {
+    --icon-url: url("../assets/images/icono-tema-dark.svg");
+}
+
+.icon-theme-light {
+    --icon-url: url("../assets/images/icono-tema-light.svg");
+}
+
+.icon-logout {
+    --icon-url: url("../assets/images/icono-logout.svg");
 }
 
 .hamburger img {

--- a/css/login.css
+++ b/css/login.css
@@ -263,17 +263,7 @@ body {
     z-index: 1000;
 }
 
-#login-theme-toggle {
+#theme-toggle.theme-btn {
     width: 40px;
     height: 40px;
-    border-radius: 50%;
-    border: 1px solid var(--border-color);
-    background-color: var(--card-bg-color);
-    color: var(--text-color);
-    font-size: 1.5rem;
-    cursor: pointer;
-    display: grid;
-    place-items: center;
-    padding: 0;
-    line-height: 1;
 }

--- a/js/common.js
+++ b/js/common.js
@@ -23,10 +23,13 @@ const navbarHTML = `
                 <li class="nav-item"><a href="inventario.html" class="nav-link">🖧 Inventario</a></li>
                 <li class="nav-separator"></li>
                 <li class="nav-item nav-item-controls">
-                    <button id="theme-toggle" class="theme-btn nav-control-btn" title="Cambiar Tema">🌙</button>
-                    <button id="logout-btn" class="header-btn nav-control-btn" title="Cerrar Sesión">
-                        <img src="assets/images/icono-logout-dark.png" alt="Cerrar Sesión" class="icon-dark">
-                        <img src="assets/images/icono-logout-light.png" alt="Cerrar Sesión" class="icon-light">
+                    <button id="theme-toggle" class="theme-btn nav-control-btn" title="Cambiar Tema" aria-label="Cambiar a tema oscuro">
+                        <span class="icon icon-theme-dark icon-dark" aria-hidden="true"></span>
+                        <span class="icon icon-theme-light icon-light" aria-hidden="true"></span>
+                    </button>
+                    <button id="logout-btn" class="header-btn nav-control-btn" title="Cerrar Sesión" aria-label="Cerrar Sesión">
+                        <span class="icon icon-logout icon-dark" aria-hidden="true"></span>
+                        <span class="icon icon-logout icon-light" aria-hidden="true"></span>
                     </button>
                 </li>
             </ul>
@@ -94,16 +97,19 @@ document.addEventListener('DOMContentLoaded', () => {
    // --- LÓGICA DEL TEMA ---
     const themeToggleBtn = document.getElementById('theme-toggle');
     if (themeToggleBtn) {
-        // Al cargar, solo necesitamos ajustar el ícono, la clase ya está puesta.
-        if (document.documentElement.classList.contains('dark-mode')) {
-            themeToggleBtn.textContent = '☀️';
-        }
+        const updateThemeToggleLabels = (isDarkMode) => {
+            const label = isDarkMode ? 'Cambiar a tema claro' : 'Cambiar a tema oscuro';
+            themeToggleBtn.setAttribute('aria-label', label);
+            themeToggleBtn.setAttribute('title', label);
+        };
+
+        updateThemeToggleLabels(document.documentElement.classList.contains('dark-mode'));
 
         themeToggleBtn.addEventListener('click', () => {
             document.documentElement.classList.toggle('dark-mode');
             const isDarkMode = document.documentElement.classList.contains('dark-mode');
             const theme = isDarkMode ? 'dark' : 'light';
-            themeToggleBtn.textContent = isDarkMode ? '☀️' : '🌙';
+            updateThemeToggleLabels(isDarkMode);
             localStorage.setItem('theme', theme);
         });
     }

--- a/login.html
+++ b/login.html
@@ -33,7 +33,10 @@
     </div>
 
     <div class="header-buttons">
-        <button id="theme-toggle" class="theme-btn" title="Cambiar Tema">🌙</button>
+        <button id="theme-toggle" class="theme-btn" title="Cambiar Tema" aria-label="Cambiar a tema oscuro">
+            <span class="icon icon-theme-dark icon-dark" aria-hidden="true"></span>
+            <span class="icon icon-theme-light icon-light" aria-hidden="true"></span>
+        </button>
     </div>
 
     <main class="login-page-main" id="login-main-content" style="visibility: hidden;">


### PR DESCRIPTION
## Summary
- replace the theme toggle emoji and logout PNGs with SVG-based icons that match the new assets
- adjust shared and login-specific styles to render the SVGs via CSS masks and inherit the active theme color
- update the theme toggle script to keep button labels in sync with the current theme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e279607258832a92ea42f8625ebc32