### PR TITLE
Corrige alineación de iconos y pestañas en descartar/consultar

### DIFF
--- a/css/consultar.css
+++ b/css/consultar.css
@@ -183,7 +183,8 @@ html.dark-mode .date-field input[type="date"]{
   display: inline-block;
   flex: 0 0 170px;
   height: 42px;
-  color: var(--primary-color);
+  color: var(--text-color);
+  transition: color .2s ease;
 }
 
 .controls-area .date-field .date-placeholder {
@@ -433,12 +434,19 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
 
 /* Detalles extra SIEMPRE visibles en escritorio */
 #detalle-extra {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 18px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px 24px;
   margin-top: 6px;
   color: var(--text-color);
   font-size: 0.95rem;
+  align-items: start;
+}
+#detalle-extra span {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  column-gap: 6px;
 }
 #detalle-extra span strong {
   color: var(--text-color);
@@ -459,7 +467,10 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
 @media (max-width: 768px) {
   /* Botón toggle visible */
   #btn-toggle-detalles {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
     padding: 6px 12px;
     font-size: 0.85rem;
     border-radius: var(--button-radius);

--- a/css/global.css
+++ b/css/global.css
@@ -494,15 +494,20 @@ html.dark-mode .theme-btn {
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
+    line-height: 1.1;
 }
 
 .button-with-icon .icon {
     flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .button-label {
     display: inline-flex;
     align-items: center;
+    line-height: 1.2;
 }
 
 .icon-theme-dark {

--- a/js/common.js
+++ b/js/common.js
@@ -26,7 +26,7 @@ const navbarHTML = `
                 </a></li>
                 <li class="nav-item"><a href="descartes.html" class="nav-link">
                     <span class="icon icon--sm icon-nav-descartes nav-icon" aria-hidden="true"></span>
-                    <span class="nav-label">Descartes</span>
+                    <span class="nav-label">Descartar</span>
                 </a></li>
                 <li class="nav-item"><a href="consultar.html" class="nav-link">
                     <span class="icon icon--sm icon-nav-consultar nav-icon" aria-hidden="true"></span>

--- a/js/consultar.js
+++ b/js/consultar.js
@@ -449,11 +449,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Tabs
   if (tabsNav) {
     tabsNav.addEventListener('click', (e) => {
-      if (!e.target.classList.contains('tab-btn')) return;
-      const tabId = e.target.dataset.tab;
+      const button = e.target.closest('.tab-btn');
+      if (!button) return;
+      const tabId = button.dataset.tab;
 
       tabsNav.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-      e.target.classList.add('active');
+      button.classList.add('active');
 
       tabContents.forEach(c => c.classList.toggle('active', c.id === `${tabId}-content`));
 


### PR DESCRIPTION
## Resumen
- corrige la alineación de iconos en botones con `button-with-icon`
- ajusta el color de iconos de filtros y el diseño del detalle de sesiones
- arregla la interacción completa de las pestañas de consulta y renombra la opción de navegación a "Descartar"

## Pruebas
- no se realizaron pruebas automatizadas

------
https://chatgpt.com/codex/tasks/task_e_68e2a215de98832abba844a436f95ec0