### PR TITLE
Refine consultar filters and mobile action toggles

### DIFF
--- a/consultar.html
+++ b/consultar.html
@@ -62,11 +62,11 @@
             </div>
             <div class="filters-group">
               <div class="date-field" data-empty="true">
-                <input type="date" id="date-start-visitantes" placeholder="dd/mm/aaaa" title="Fecha de inicio" />
+                <input type="date" id="date-start-visitantes" title="Fecha de inicio" aria-label="Fecha de inicio" />
                 <span class="date-placeholder" aria-hidden="true">dd/mm/aaaa</span>
               </div>
               <div class="date-field" data-empty="true">
-                <input type="date" id="date-end-visitantes" placeholder="dd/mm/aaaa" title="Fecha de fin" />
+                <input type="date" id="date-end-visitantes" title="Fecha de fin" aria-label="Fecha de fin" />
                 <span class="date-placeholder" aria-hidden="true">dd/mm/aaaa</span>
               </div>
             </div>
@@ -113,11 +113,11 @@
               </div>
               <div class="filters-group">
                 <div class="date-field" data-empty="true">
-                  <input type="date" id="date-start-descartes" placeholder="dd/mm/aaaa" title="Fecha de inicio" />
+                  <input type="date" id="date-start-descartes" title="Fecha de inicio" aria-label="Fecha de inicio" />
                   <span class="date-placeholder" aria-hidden="true">dd/mm/aaaa</span>
                 </div>
                 <div class="date-field" data-empty="true">
-                  <input type="date" id="date-end-descartes" placeholder="dd/mm/aaaa" title="Fecha de fin" />
+                  <input type="date" id="date-end-descartes" title="Fecha de fin" aria-label="Fecha de fin" />
                   <span class="date-placeholder" aria-hidden="true">dd/mm/aaaa</span>
                 </div>
               </div>
@@ -177,17 +177,24 @@
             </div>
           </div>
 
-          <div class="controls-area">
-            <input
-              type="search"
-              id="search-equipos"
-              placeholder="Buscar por descripción, marca, modelo, serie o marbete..." />
-            <span id="equipos-total" class="count-pill" aria-live="polite">0 equipos</span>
-            <!-- Botón Añadir Equipo se adapta a móvil -->
-            <button id="btn-agregar-equipo" class="btn-principal btn-anadir-equipo button-with-icon" type="button">
-              <span class="icon icon--sm icon-plus" aria-hidden="true"></span>
-              <span class="button-label">Añadir Equipo</span>
-            </button>
+          <div class="controls-area" data-controls="equipos">
+            <div class="controls-row controls-row--primary">
+              <button class="search-toggle button-with-icon" type="button" aria-expanded="false" aria-controls="search-equipos">
+                <span class="icon icon--sm icon-search" aria-hidden="true"></span>
+                <span class="sr-only">Mostrar búsqueda</span>
+              </button>
+              <div class="search-field">
+                <input
+                  type="search"
+                  id="search-equipos"
+                  placeholder="Buscar por descripción, marca, modelo, serie o marbete..." />
+              </div>
+              <span id="equipos-total" class="count-pill" aria-live="polite">0 equipos</span>
+              <button id="btn-agregar-equipo" class="btn-principal btn-anadir-equipo button-with-icon" type="button">
+                <span class="icon icon--sm icon-plus" aria-hidden="true"></span>
+                <span class="button-label">Añadir Equipo</span>
+              </button>
+            </div>
           </div>
 
           <div class="table-container">

--- a/css/consultar.css
+++ b/css/consultar.css
@@ -185,8 +185,9 @@ html.dark-mode .date-field input[type="date"]{
 }
 
 .controls-area[data-controls] .controls-row--meta .count-pill {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   min-width: 0;
+  margin-right: auto;
 }
 
 .controls-area[data-controls] .controls-row--meta .btn-export {
@@ -195,28 +196,69 @@ html.dark-mode .date-field input[type="date"]{
 
 .controls-area[data-controls] .search-toggle {
   display: none;
+  width: 42px;
   height: 42px;
-  padding: 0 14px;
-  border: none;
-  border-radius: var(--button-radius);
+  padding: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
   background-color: var(--input-bg-color);
   color: var(--text-color);
   cursor: pointer;
-  transition: background-color .2s ease;
+  transition: background-color .2s ease, color .2s ease, border-color .2s ease, box-shadow .2s ease;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--shadow-color) 60%, transparent);
+  flex: 0 0 42px;
+}
+
+html.dark-mode .controls-area[data-controls] .search-toggle {
+  border-color: color-mix(in srgb, var(--border-color) 55%, transparent);
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--primary-color) 20%, transparent);
 }
 
 .controls-area[data-controls] .search-toggle:hover {
   background-color: color-mix(in srgb, var(--input-bg-color) 70%, transparent);
+  box-shadow: 0 3px 10px color-mix(in srgb, var(--shadow-color) 80%, transparent);
 }
 
 .controls-area[data-controls].search-expanded .search-toggle {
   background-color: var(--primary-color);
+  border-color: color-mix(in srgb, var(--primary-color) 45%, transparent);
   color: #fff;
+  box-shadow: 0 3px 10px color-mix(in srgb, var(--primary-color) 40%, transparent);
 }
 
 .controls-area[data-controls] .search-field {
   flex: 1 1 320px;
   min-width: 0;
+}
+
+.controls-area[data-controls] .search-toggle:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
+  outline-offset: 2px;
+}
+
+.controls-area[data-controls="equipos"] .controls-row--primary {
+  flex-wrap: wrap;
+}
+
+.controls-area[data-controls="equipos"] .search-toggle {
+  order: 1;
+}
+
+.controls-area[data-controls="equipos"] .search-field {
+  order: 2;
+}
+
+.controls-area[data-controls="equipos"] #equipos-total {
+  order: 3;
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
+.controls-area[data-controls="equipos"] #btn-agregar-equipo {
+  order: 4;
+  flex: 0 0 auto;
 }
 
 .controls-area[data-controls] .search-field input[type="search"] {
@@ -252,6 +294,26 @@ html.dark-mode .date-field input[type="date"]{
     display: inline-flex;
     align-items: center;
     justify-content: center;
+  }
+
+  .controls-area[data-controls="equipos"] .controls-row--primary {
+    flex-wrap: nowrap;
+  }
+
+  .controls-area[data-controls="equipos"].search-expanded .controls-row--primary {
+    flex-wrap: wrap;
+  }
+
+  .controls-area[data-controls="equipos"].search-expanded .search-field {
+    order: 4;
+    display: block;
+    flex: 1 1 100%;
+    width: 100%;
+  }
+
+  .controls-area[data-controls="equipos"].search-expanded #equipos-total,
+  .controls-area[data-controls="equipos"].search-expanded #btn-agregar-equipo {
+    margin-top: 8px;
   }
 
   .controls-area[data-controls] .controls-row--primary {
@@ -319,13 +381,13 @@ html.dark-mode .date-field input[type="date"]{
   box-shadow: 0 2px 6px var(--shadow-color);
 }
 
-/* Botón Añadir Equipo ocupa todo el ancho en móvil */
+/* Botón Añadir Equipo en móvil acompaña al contador */
 @media (max-width: 768px) {
   #btn-agregar-equipo {
-    display: block;
-    width: 100%;
+    display: inline-flex;
+    width: auto;
     text-align: center;
-    margin-top: 0.8rem;
+    margin-top: 0;
   }
 }
 
@@ -706,9 +768,9 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
 }
 
 @media (max-width: 768px) {
-  .controls-area .count-pill {
+  .controls-area:not([data-controls]) .count-pill {
     grid-column: 1 / -1;
-    width: 100%;
+    width: auto;
     margin-left: 0;
     justify-content: center;
   }

--- a/css/global.css
+++ b/css/global.css
@@ -200,6 +200,77 @@ button:disabled {
     cursor: not-allowed;
 }
 
+/* --- Tablas responsivas: columna de acciones --- */
+@media (max-width: 768px) {
+    .table-container.has-actions-toggle {
+        padding-right: 64px;
+    }
+
+    .table-container .actions-toggle {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        bottom: 16px;
+        width: 42px;
+        border: none;
+        border-radius: 999px;
+        background: var(--primary-color);
+        color: #fff;
+        font-weight: 600;
+        font-size: 0.85rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 6px;
+        cursor: pointer;
+        writing-mode: vertical-rl;
+        text-orientation: mixed;
+        transform: rotate(180deg);
+        letter-spacing: 0.08em;
+        box-shadow: 0 4px 14px color-mix(in srgb, var(--primary-color) 40%, transparent);
+        z-index: 5;
+        transition: background-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .table-container .actions-toggle:hover {
+        background: var(--primary-hover-color);
+        box-shadow: 0 4px 16px color-mix(in srgb, var(--primary-hover-color) 45%, transparent);
+    }
+
+    .table-container .actions-toggle__icon {
+        font-size: 1rem;
+        margin-bottom: 12px;
+        transform: rotate(180deg);
+    }
+
+    .table-container .actions-toggle.is-hidden {
+        display: none;
+    }
+
+    .table-container .actions-toggle:focus-visible {
+        outline: 3px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
+        outline-offset: 2px;
+    }
+
+    .table-container.actions-open .actions-toggle {
+        background: var(--primary-hover-color);
+        box-shadow: 0 4px 16px color-mix(in srgb, var(--primary-hover-color) 45%, transparent);
+    }
+
+    .table-container.has-actions-toggle table.actions-collapsible {
+        transition: opacity 0.2s ease;
+    }
+
+    .table-container.has-actions-toggle table.actions-collapsed th:last-child,
+    .table-container.has-actions-toggle table.actions-collapsed td:last-child {
+        display: none;
+    }
+}
+
+html.dark-mode .table-container .actions-toggle {
+    box-shadow: 0 4px 14px color-mix(in srgb, var(--primary-color) 55%, transparent);
+}
+
 select {
     -webkit-appearance: none;
     -moz-appearance: none;

--- a/js/consultar.js
+++ b/js/consultar.js
@@ -166,6 +166,120 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   }
 
+  function initActionsColumnToggle(tableId) {
+    const table = document.getElementById(tableId);
+    if (!table) return;
+
+    const container = table.closest('.table-container');
+    if (!container) return;
+
+    const mobileMedia = window.matchMedia('(max-width: 768px)');
+    let toggleBtn = null;
+    let userExpanded = false;
+    let autoExpanded = false;
+
+    const ensureCollapsedState = (shouldCollapse) => {
+      table.classList.toggle('actions-collapsed', shouldCollapse);
+      table.classList.add('actions-collapsible');
+      container.classList.toggle('actions-open', !shouldCollapse);
+    };
+
+    const updateToggleVisualState = () => {
+      if (!toggleBtn) return;
+      toggleBtn.setAttribute('aria-pressed', userExpanded ? 'true' : 'false');
+      toggleBtn.setAttribute('aria-label', userExpanded ? 'Ocultar columna de acciones' : 'Mostrar columna de acciones');
+      toggleBtn.title = userExpanded ? 'Ocultar columna de acciones' : 'Mostrar columna de acciones';
+      toggleBtn.dataset.state = userExpanded ? 'open' : 'closed';
+    };
+
+    const handleToggleClick = () => {
+      userExpanded = !userExpanded;
+      autoExpanded = false;
+      ensureCollapsedState(!userExpanded);
+      updateToggleVisualState();
+      if (toggleBtn) {
+        toggleBtn.classList.remove('is-hidden');
+      }
+    };
+
+    const handleScroll = () => {
+      if (!toggleBtn) return;
+      const { scrollLeft, clientWidth, scrollWidth } = container;
+      const atEnd = Math.ceil(scrollLeft + clientWidth) >= scrollWidth - 1;
+
+      if (atEnd) {
+        if (!autoExpanded) {
+          autoExpanded = true;
+          ensureCollapsedState(false);
+          toggleBtn.classList.add('is-hidden');
+        }
+        return;
+      }
+
+      if (autoExpanded) {
+        autoExpanded = false;
+        ensureCollapsedState(!userExpanded);
+      }
+      toggleBtn.classList.remove('is-hidden');
+    };
+
+    const handleResize = () => {
+      if (!toggleBtn) return;
+      handleScroll();
+    };
+
+    const enableMobileBehaviour = () => {
+      if (toggleBtn) return;
+
+      toggleBtn = document.createElement('button');
+      toggleBtn.type = 'button';
+      toggleBtn.className = 'actions-toggle';
+      toggleBtn.innerHTML = '<span class="actions-toggle__icon" aria-hidden="true">↔</span><span class="actions-toggle__label">Acciones</span>';
+      toggleBtn.setAttribute('aria-pressed', 'false');
+      toggleBtn.setAttribute('aria-label', 'Mostrar columna de acciones');
+      toggleBtn.title = 'Mostrar columna de acciones';
+
+      container.appendChild(toggleBtn);
+      container.classList.add('has-actions-toggle');
+      userExpanded = false;
+      autoExpanded = false;
+      ensureCollapsedState(true);
+      updateToggleVisualState();
+
+      toggleBtn.addEventListener('click', handleToggleClick);
+      container.addEventListener('scroll', handleScroll, { passive: true });
+      window.addEventListener('resize', handleResize);
+      handleScroll();
+    };
+
+    const disableMobileBehaviour = () => {
+      if (!toggleBtn) return;
+
+      toggleBtn.removeEventListener('click', handleToggleClick);
+      toggleBtn.remove();
+      toggleBtn = null;
+
+      container.classList.remove('has-actions-toggle', 'actions-open');
+      table.classList.remove('actions-collapsed', 'actions-collapsible');
+      container.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
+
+      userExpanded = false;
+      autoExpanded = false;
+    };
+
+    const handleMediaChange = (event) => {
+      if (event.matches) {
+        enableMobileBehaviour();
+      } else {
+        disableMobileBehaviour();
+      }
+    };
+
+    handleMediaChange(mobileMedia);
+    mobileMedia.addEventListener('change', handleMediaChange);
+  }
+
   // --- 3) Utilidades ---
   function showToast(message, type = 'success') {
     clearTimeout(toastTimeout);
@@ -524,6 +638,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   updateSesionesTotal(0);
   updateEquiposTotalBadge(0);
   setupResponsiveControls();
+  ['table-visitantes', 'table-descartes', 'table-equipos-sesion'].forEach(initActionsColumnToggle);
 
   // --- 5) Eventos ---
 

--- a/js/descartes.js
+++ b/js/descartes.js
@@ -68,6 +68,120 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 3000);
   }
 
+  function initActionsColumnToggle(tableId) {
+    const table = document.getElementById(tableId);
+    if (!table) return;
+
+    const container = table.closest('.table-container');
+    if (!container) return;
+
+    const mobileMedia = window.matchMedia('(max-width: 768px)');
+    let toggleBtn = null;
+    let userExpanded = false;
+    let autoExpanded = false;
+
+    const ensureCollapsedState = (shouldCollapse) => {
+      table.classList.toggle('actions-collapsed', shouldCollapse);
+      table.classList.add('actions-collapsible');
+      container.classList.toggle('actions-open', !shouldCollapse);
+    };
+
+    const updateToggleVisualState = () => {
+      if (!toggleBtn) return;
+      toggleBtn.setAttribute('aria-pressed', userExpanded ? 'true' : 'false');
+      toggleBtn.setAttribute('aria-label', userExpanded ? 'Ocultar columna de acciones' : 'Mostrar columna de acciones');
+      toggleBtn.title = userExpanded ? 'Ocultar columna de acciones' : 'Mostrar columna de acciones';
+      toggleBtn.dataset.state = userExpanded ? 'open' : 'closed';
+    };
+
+    const handleToggleClick = () => {
+      userExpanded = !userExpanded;
+      autoExpanded = false;
+      ensureCollapsedState(!userExpanded);
+      updateToggleVisualState();
+      if (toggleBtn) {
+        toggleBtn.classList.remove('is-hidden');
+      }
+    };
+
+    const handleScroll = () => {
+      if (!toggleBtn) return;
+      const { scrollLeft, clientWidth, scrollWidth } = container;
+      const atEnd = Math.ceil(scrollLeft + clientWidth) >= scrollWidth - 1;
+
+      if (atEnd) {
+        if (!autoExpanded) {
+          autoExpanded = true;
+          ensureCollapsedState(false);
+          toggleBtn.classList.add('is-hidden');
+        }
+        return;
+      }
+
+      if (autoExpanded) {
+        autoExpanded = false;
+        ensureCollapsedState(!userExpanded);
+      }
+      toggleBtn.classList.remove('is-hidden');
+    };
+
+    const handleResize = () => {
+      if (!toggleBtn) return;
+      handleScroll();
+    };
+
+    const enableMobileBehaviour = () => {
+      if (toggleBtn) return;
+
+      toggleBtn = document.createElement('button');
+      toggleBtn.type = 'button';
+      toggleBtn.className = 'actions-toggle';
+      toggleBtn.innerHTML = '<span class="actions-toggle__icon" aria-hidden="true">↔</span><span class="actions-toggle__label">Acciones</span>';
+      toggleBtn.setAttribute('aria-pressed', 'false');
+      toggleBtn.setAttribute('aria-label', 'Mostrar columna de acciones');
+      toggleBtn.title = 'Mostrar columna de acciones';
+
+      container.appendChild(toggleBtn);
+      container.classList.add('has-actions-toggle');
+      userExpanded = false;
+      autoExpanded = false;
+      ensureCollapsedState(true);
+      updateToggleVisualState();
+
+      toggleBtn.addEventListener('click', handleToggleClick);
+      container.addEventListener('scroll', handleScroll, { passive: true });
+      window.addEventListener('resize', handleResize);
+      handleScroll();
+    };
+
+    const disableMobileBehaviour = () => {
+      if (!toggleBtn) return;
+
+      toggleBtn.removeEventListener('click', handleToggleClick);
+      toggleBtn.remove();
+      toggleBtn = null;
+
+      container.classList.remove('has-actions-toggle', 'actions-open');
+      table.classList.remove('actions-collapsed', 'actions-collapsible');
+      container.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
+
+      userExpanded = false;
+      autoExpanded = false;
+    };
+
+    const handleMediaChange = (event) => {
+      if (event.matches) {
+        enableMobileBehaviour();
+      } else {
+        disableMobileBehaviour();
+      }
+    };
+
+    handleMediaChange(mobileMedia);
+    mobileMedia.addEventListener('change', handleMediaChange);
+  }
+
   window.clearWorkInProgress = () => {
     window.isWorkInProgress = false;
     sessionStorage.removeItem(SESSION_STORAGE_KEY);
@@ -201,6 +315,8 @@ document.addEventListener('DOMContentLoaded', () => {
       submitBtn.textContent = 'Crear Sesión';
     }
   });
+
+  initActionsColumnToggle('tabla-equipos');
   
   formEquipo.addEventListener('submit', async (e) => {
     e.preventDefault();

--- a/js/inventario.js
+++ b/js/inventario.js
@@ -194,6 +194,120 @@ document.addEventListener('DOMContentLoaded', async () => {
     toast.className = toast.className.replace('show', '');
   }
 
+  function initActionsColumnToggle(tableId) {
+    const table = document.getElementById(tableId);
+    if (!table) return;
+
+    const container = table.closest('.table-container');
+    if (!container) return;
+
+    const mobileMedia = window.matchMedia('(max-width: 768px)');
+    let toggleBtn = null;
+    let userExpanded = false;
+    let autoExpanded = false;
+
+    const ensureCollapsedState = (shouldCollapse) => {
+      table.classList.toggle('actions-collapsed', shouldCollapse);
+      table.classList.add('actions-collapsible');
+      container.classList.toggle('actions-open', !shouldCollapse);
+    };
+
+    const updateToggleVisualState = () => {
+      if (!toggleBtn) return;
+      toggleBtn.setAttribute('aria-pressed', userExpanded ? 'true' : 'false');
+      toggleBtn.setAttribute('aria-label', userExpanded ? 'Ocultar columna de acciones' : 'Mostrar columna de acciones');
+      toggleBtn.title = userExpanded ? 'Ocultar columna de acciones' : 'Mostrar columna de acciones';
+      toggleBtn.dataset.state = userExpanded ? 'open' : 'closed';
+    };
+
+    const handleToggleClick = () => {
+      userExpanded = !userExpanded;
+      autoExpanded = false;
+      ensureCollapsedState(!userExpanded);
+      updateToggleVisualState();
+      if (toggleBtn) {
+        toggleBtn.classList.remove('is-hidden');
+      }
+    };
+
+    const handleScroll = () => {
+      if (!toggleBtn) return;
+      const { scrollLeft, clientWidth, scrollWidth } = container;
+      const atEnd = Math.ceil(scrollLeft + clientWidth) >= scrollWidth - 1;
+
+      if (atEnd) {
+        if (!autoExpanded) {
+          autoExpanded = true;
+          ensureCollapsedState(false);
+          toggleBtn.classList.add('is-hidden');
+        }
+        return;
+      }
+
+      if (autoExpanded) {
+        autoExpanded = false;
+        ensureCollapsedState(!userExpanded);
+      }
+      toggleBtn.classList.remove('is-hidden');
+    };
+
+    const handleResize = () => {
+      if (!toggleBtn) return;
+      handleScroll();
+    };
+
+    const enableMobileBehaviour = () => {
+      if (toggleBtn) return;
+
+      toggleBtn = document.createElement('button');
+      toggleBtn.type = 'button';
+      toggleBtn.className = 'actions-toggle';
+      toggleBtn.innerHTML = '<span class="actions-toggle__icon" aria-hidden="true">↔</span><span class="actions-toggle__label">Acciones</span>';
+      toggleBtn.setAttribute('aria-pressed', 'false');
+      toggleBtn.setAttribute('aria-label', 'Mostrar columna de acciones');
+      toggleBtn.title = 'Mostrar columna de acciones';
+
+      container.appendChild(toggleBtn);
+      container.classList.add('has-actions-toggle');
+      userExpanded = false;
+      autoExpanded = false;
+      ensureCollapsedState(true);
+      updateToggleVisualState();
+
+      toggleBtn.addEventListener('click', handleToggleClick);
+      container.addEventListener('scroll', handleScroll, { passive: true });
+      window.addEventListener('resize', handleResize);
+      handleScroll();
+    };
+
+    const disableMobileBehaviour = () => {
+      if (!toggleBtn) return;
+
+      toggleBtn.removeEventListener('click', handleToggleClick);
+      toggleBtn.remove();
+      toggleBtn = null;
+
+      container.classList.remove('has-actions-toggle', 'actions-open');
+      table.classList.remove('actions-collapsed', 'actions-collapsible');
+      container.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
+
+      userExpanded = false;
+      autoExpanded = false;
+    };
+
+    const handleMediaChange = (event) => {
+      if (event.matches) {
+        enableMobileBehaviour();
+      } else {
+        disableMobileBehaviour();
+      }
+    };
+
+    handleMediaChange(mobileMedia);
+    mobileMedia.addEventListener('change', handleMediaChange);
+  }
+
   function toggleLoader(show) {
     if (!loader || !mainContent) return;
     loader.style.display = show ? 'flex' : 'none';
@@ -971,6 +1085,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   sessionUserId = session.user?.id || null;
   toggleLoader(true);
+  initActionsColumnToggle('tabla-inventario');
   attachEventListeners();
   await fetchRecords({ showLoader: false });
   toggleLoader(false);


### PR DESCRIPTION
## Summary
- update the consultar filters to rely on custom placeholders and restructure the session detail controls for consistent mobile layout
- refresh search toggle styling and counter sizing to match the compact UI expectations
- add a reusable mobile toggle that collapses/expands action columns across consultar, descartes and inventario tables

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e2b59a3464832ab5f5713dcb6fc5ea