### PR TITLE
Ajustar estilo y comportamiento de modales

### DIFF
--- a/consultar.html
+++ b/consultar.html
@@ -286,7 +286,10 @@
             </button>
             <button type="submit" class="btn-principal button-with-icon">
               <span class="icon icon--sm icon-save" aria-hidden="true"></span>
-              <span class="button-label">Guardar Cambios</span>
+              <span class="button-label">
+                <span class="label-desktop">Guardar Cambios</span>
+                <span class="label-mobile">Aplicar</span>
+              </span>
             </button>
           </div>
         </form>
@@ -352,7 +355,10 @@
             </button>
             <button type="submit" class="btn-principal button-with-icon">
               <span class="icon icon--sm icon-save" aria-hidden="true"></span>
-              <span class="button-label">Aplicar Cambios</span>
+              <span class="button-label">
+                <span class="label-desktop">Aplicar Cambios</span>
+                <span class="label-mobile">Aplicar</span>
+              </span>
             </button>
           </div>
         </form>
@@ -464,7 +470,10 @@
             </button>
             <button type="submit" class="btn-principal button-with-icon">
               <span class="icon icon--sm icon-save" aria-hidden="true"></span>
-              <span class="button-label">Guardar Cambios</span>
+              <span class="button-label">
+                <span class="label-desktop">Guardar Cambios</span>
+                <span class="label-mobile">Aplicar</span>
+              </span>
             </button>
           </div>
         </form>

--- a/css/global.css
+++ b/css/global.css
@@ -511,6 +511,28 @@ html.dark-mode .theme-btn {
     line-height: 1.2;
 }
 
+.button-label .label-mobile {
+    display: none;
+}
+
+.button-label .label-desktop {
+    display: inline-flex;
+}
+
+@media (max-width: 600px) {
+    .button-label {
+        justify-content: center;
+    }
+
+    .button-label .label-desktop {
+        display: none;
+    }
+
+    .button-label .label-mobile {
+        display: inline-flex;
+    }
+}
+
 .icon-theme-dark {
     --icon-url: url("../assets/images/icono-tema-dark.svg");
 }
@@ -658,15 +680,15 @@ body.nav-open .icon-menu { display: none; }
 
 .modal-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
+    inset: 0;
     width: 100%;
     height: 100%;
     background-color: rgba(0, 0, 0, 0.6);
     backdrop-filter: blur(5px);
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    display: grid;
+    place-items: center;
+    padding: clamp(16px, 4vw, 32px);
+    overflow-y: auto;
     z-index: 3000;
     opacity: 0;
     visibility: hidden;
@@ -683,12 +705,17 @@ body.nav-open .icon-menu { display: none; }
     padding: 30px;
     border-radius: 12px;
     box-shadow: 0 10px 30px var(--shadow-color);
-    width: 90%;
-    max-width: 500px;
+    width: min(520px, 100%);
+    max-width: 520px;
     position: relative;
     text-align: center;
     transform: scale(0.95);
     transition: transform 0.2s ease;
+    margin: auto;
+    max-height: min(90dvh, 680px);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
 }
 
 .modal-overlay.visible .modal-content {
@@ -697,31 +724,26 @@ body.nav-open .icon-menu { display: none; }
 
 .modal-content h2 {
     text-align: center;
+    margin-top: 0.5rem;
+}
+
+@media (max-width: 768px) {
+    .modal-content {
+        padding: 24px;
+        gap: 1rem;
+    }
 }
 
 @media (pointer: coarse) {
-    .modal-overlay {
-        align-items: flex-start;
-        padding: 16px;
-        overflow-y: auto;
-    }
-
-    .modal-overlay.visible {
-        overflow-y: auto;
-    }
-
     .modal-content {
-        margin-top: 16px;
-        margin-bottom: 16px;
-        max-height: calc(100dvh - 32px);
-        overflow-y: auto;
+        max-height: calc(100dvh - clamp(40px, 8vh, 80px));
     }
 }
 
 .modal-close-btn {
     position: absolute;
-    top: 10px;
-    right: 15px;
+    top: 12px;
+    right: 12px;
     background: transparent;
     border: none;
     color: var(--border-color);
@@ -740,12 +762,17 @@ body.nav-open .icon-menu { display: none; }
     color: var(--text-color);
 }
 
+.modal-close-btn .icon {
+    width: 1em;
+    height: 1em;
+}
+
 .modal-buttons {
     display: flex;
     justify-content: center;
-    align-items: center;
-    gap: 15px;
-    margin-top: 25px;
+    align-items: stretch;
+    gap: 12px;
+    margin-top: 16px;
     flex-wrap: wrap;
 }
 
@@ -772,25 +799,19 @@ body.nav-open .icon-menu { display: none; }
 
 @media (max-width: 600px) {
     .modal-content {
-        padding: 24px 20px;
+        padding: 22px 18px 24px;
     }
 
     .modal-close-btn {
-        top: 4px;
+        top: 8px;
         right: 8px;
-        padding: 4px;
-    }
-
-    .modal-buttons {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 12px;
-        margin-top: 20px;
+        padding: 6px;
     }
 
     .modal-buttons .button-with-icon {
-        width: 100%;
-        padding: 0.75rem 1rem;
+        flex: 1 1 calc(50% - 10px);
+        min-width: 0;
+        padding: 0.65rem 0.75rem;
         font-size: 0.95rem;
         gap: 0.35rem;
     }
@@ -809,8 +830,35 @@ body.nav-open .icon-menu { display: none; }
     text-align: left;
 }
 
+.modal-buttons .button-with-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.25rem;
+    font-weight: 600;
+    gap: 0.45rem;
+}
+
+.modal-buttons .button-with-icon .icon {
+    width: 1.05em;
+    height: 1.05em;
+}
+
+.modal-content form .modal-buttons {
+    width: 100%;
+    justify-content: flex-end;
+}
+
+@media (max-width: 600px) {
+    .modal-content form .modal-buttons {
+        justify-content: center;
+    }
+}
+
 /* ▼ INICIO DEL CAMBIO: Estilos para hacer el formulario del modal desplazable ▼ */
 .modal-form-container {
+    flex: 1 1 auto;
+    width: 100%;
     max-height: 70vh; /* Fallback para navegadores antiguos */
     max-height: 70svh;
     max-height: 70dvh; /* Mantiene el modal visible con teclados virtuales */

--- a/descartes.html
+++ b/descartes.html
@@ -227,9 +227,12 @@
                             <span class="icon icon--sm icon-close-cancel" aria-hidden="true"></span>
                             <span class="button-label">Cancelar</span>
                         </button>
-                        <button type="submit" class="btn-principal button-with-icon" data-label-mobile="Aplicar">
+                        <button type="submit" class="btn-principal button-with-icon">
                             <span class="icon icon--sm icon-save" aria-hidden="true"></span>
-                            <span class="button-label">Aplicar Cambios</span>
+                            <span class="button-label">
+                                <span class="label-desktop">Aplicar Cambios</span>
+                                <span class="label-mobile">Aplicar</span>
+                            </span>
                         </button>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary
- Centrar los modales en toda la web y uniformar su estructura y espaciados en desktop y móvil.
- Ajustar botones, iconos y tipografía de los modales para que mantengan alineación horizontal y tamaño proporcional en pantallas pequeñas.
- Simplificar las etiquetas de botones de acción en móviles mostrando versiones compactas como “Aplicar”.

## Testing
- No automated tests were run (not available).


------
https://chatgpt.com/codex/tasks/task_e_68e2d33b3d04832aa0b4becf1ad5b0c8