### PR TITLE
Actualiza botones del modal de edición en descartes

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -839,6 +839,12 @@ body.nav-open .icon-menu { display: none; }
     gap: 0.45rem;
 }
 
+.modal-buttons .btn-principal {
+    width: auto;
+    margin-top: 0;
+    padding: 0.75rem 1.25rem;
+}
+
 .modal-buttons .button-with-icon .icon {
     width: 1.05em;
     height: 1.05em;

--- a/descartes.html
+++ b/descartes.html
@@ -228,11 +228,8 @@
                             <span class="button-label">Cancelar</span>
                         </button>
                         <button type="submit" class="btn-principal button-with-icon">
-                            <span class="icon icon--sm icon-save" aria-hidden="true"></span>
-                            <span class="button-label">
-                                <span class="label-desktop">Aplicar Cambios</span>
-                                <span class="label-mobile">Aplicar</span>
-                            </span>
+                            <span class="icon icon--sm icon-check" aria-hidden="true"></span>
+                            <span class="button-label">Aplicar</span>
                         </button>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary
- ajusta los textos de los botones del modal de edición de equipos en descartes para que muestren "Cancelar" y "Aplicar" con sus íconos correspondientes
- alinea el estilo del botón principal dentro del modal con los botones de confirmación para mantener el mismo tamaño en pantallas móviles

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e2d6dab7f0832a813d04d95828cc58