### PR TITLE
Fix icon alignment for discard buttons on desktop

### DIFF
--- a/css/descartes.css
+++ b/css/descartes.css
@@ -233,8 +233,8 @@
 
     .form-equipo > .btn-principal,
     .finalizar-seccion > .btn-finalizar {
-        display: block;
-        max-width: 400px;
+        display: inline-flex;
+        width: min(100%, 400px);
         margin-left: auto;
         margin-right: auto;
     }


### PR DESCRIPTION
## Summary
- keep the Add Equipment and Finish Discard buttons as inline-flex containers on desktop
- constrain their width while allowing automatic centering so the icons remain vertically aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2db7089ac832aa1fe6750fb0c4bcc