### PR TITLE
Fix date filter calendar buttons on consultar page

### DIFF
--- a/consultar.html
+++ b/consultar.html
@@ -61,18 +61,18 @@
               <input type="search" id="search-visitantes" placeholder="Buscar por nombre, apellido o cédula..." />
             </div>
             <div class="filters-group" role="group" aria-label="Filtros de fecha">
-              <div class="date-field" data-empty="true">
+              <label class="date-field" data-empty="true">
                 <span class="date-display" aria-hidden="true">
                   <span class="date-display__text"></span>
                 </span>
                 <input type="date" id="date-start-visitantes" title="Fecha de inicio" aria-label="Fecha de inicio" />
-              </div>
-              <div class="date-field" data-empty="true">
+              </label>
+              <label class="date-field" data-empty="true">
                 <span class="date-display" aria-hidden="true">
                   <span class="date-display__text"></span>
                 </span>
                 <input type="date" id="date-end-visitantes" title="Fecha de fin" aria-label="Fecha de fin" />
-              </div>
+              </label>
             </div>
             <span id="visitantes-total" class="count-pill" aria-live="polite">0 registros</span>
             <button id="export-visitantes-btn" class="btn-export button-with-icon">
@@ -118,18 +118,18 @@
                 <input type="search" id="search-descartes" placeholder="Buscar por Unidad Administrativa o SIACE..." />
               </div>
               <div class="filters-group" role="group" aria-label="Filtros de fecha">
-                <div class="date-field" data-empty="true">
+                <label class="date-field" data-empty="true">
                   <span class="date-display" aria-hidden="true">
                     <span class="date-display__text"></span>
                   </span>
                   <input type="date" id="date-start-descartes" title="Fecha de inicio" aria-label="Fecha de inicio" />
-                </div>
-                <div class="date-field" data-empty="true">
+                </label>
+                <label class="date-field" data-empty="true">
                   <span class="date-display" aria-hidden="true">
                     <span class="date-display__text"></span>
                   </span>
                   <input type="date" id="date-end-descartes" title="Fecha de fin" aria-label="Fecha de fin" />
-                </div>
+                </label>
               </div>
               <span id="sesiones-total" class="count-pill" aria-live="polite">0 sesiones</span>
               <button id="export-descartes-btn" class="btn-export button-with-icon">

--- a/css/consultar.css
+++ b/css/consultar.css
@@ -320,19 +320,20 @@ html.dark-mode .controls-area[data-controls] .search-toggle {
   -webkit-mask: url("../assets/images/icono-calendar.svg") center/contain no-repeat;
   opacity: 0.95;
   pointer-events: none;
+  z-index: 0;
 }
 
 .controls-area .date-field[data-empty="true"] {
   padding: 0;
   min-width: 42px;
   width: 42px;
+  aspect-ratio: 1;
   box-shadow: 0 2px 4px color-mix(in srgb, var(--shadow-color) 45%, transparent);
 }
 
 .controls-area .date-field[data-empty="true"]::before {
-  position: static;
-  transform: none;
-  margin: 0;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .controls-area .date-field[data-empty="true"] .date-display__text {
@@ -349,6 +350,8 @@ html.dark-mode .controls-area[data-controls] .search-toggle {
   font-size: 0.9rem;
   font-weight: 600;
   white-space: nowrap;
+  position: relative;
+  z-index: 0;
 }
 
 .controls-area .date-display__text {
@@ -364,6 +367,7 @@ html.dark-mode .controls-area[data-controls] .search-toggle {
   border: none;
   background: transparent;
   cursor: pointer;
+  z-index: 1;
 }
 
 .controls-area .date-field:focus-within {

--- a/js/consultar.js
+++ b/js/consultar.js
@@ -1249,14 +1249,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         input.showPicker();
         return;
       }
-      try { input.focus(); } catch(_) {}
+      try { input.focus({ preventScroll: true }); }
+      catch(_) {
+        try { input.focus(); } catch(_) {}
+      }
       try { input.click(); } catch(_) {}
     };
 
-    wrapper.addEventListener('click', (e) => {
-      if (e.target === input) return;
-      e.preventDefault();
-      openPicker();
+    wrapper.addEventListener('click', (event) => {
+      if (event.target === input) return;
+      if (typeof input.showPicker === 'function') {
+        event.preventDefault();
+        openPicker();
+      }
     });
 
     if (!wrapper.hasAttribute('tabindex')) {


### PR DESCRIPTION
## Summary
- convert the date filter wrappers into labels so the native picker can be triggered from anywhere on the button
- center the calendar icon inside the circular placeholder state and ensure the invisible input covers the whole control
- adjust the date picker handler to avoid blocking browsers without `showPicker` support while keeping keyboard access

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e30e638004832a8a4ca4d7cab71bd4