### PR TITLE
Fix date filter button click target

### DIFF
--- a/js/consultar.js
+++ b/js/consultar.js
@@ -1257,11 +1257,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     wrapper.addEventListener('click', (event) => {
-      if (event.target === input) return;
       if (typeof input.showPicker === 'function') {
         event.preventDefault();
-        openPicker();
       }
+      openPicker();
     });
 
     if (!wrapper.hasAttribute('tabindex')) {


### PR DESCRIPTION
## Summary
- ensure the date filter buttons open the native date picker when clicking anywhere on the control by always invoking the picker logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e310ce7920832ab5f76318d0b1fc1f