### PR TITLE
Ajustar UI de consultar para móviles y tooltips

### DIFF
--- a/consultar.html
+++ b/consultar.html
@@ -52,8 +52,11 @@
       <!-- Tab: Visitantes -->
       <div id="visitantes-content" class="tab-content active">
         <div class="controls-area" data-controls="visitantes">
+          <div class="controls-count">
+            <span id="visitantes-total" class="count-pill" aria-live="polite">0 registros</span>
+          </div>
           <div class="controls-row controls-row--inline">
-            <button class="search-toggle button-with-icon" type="button" aria-expanded="false" aria-controls="search-visitantes">
+            <button class="search-toggle button-with-icon" type="button" aria-expanded="false" aria-controls="search-visitantes" title="Mostrar búsqueda">
               <span class="icon icon--sm icon-search" aria-hidden="true"></span>
               <span class="sr-only">Mostrar búsqueda</span>
             </button>
@@ -74,7 +77,6 @@
                 <input type="date" id="date-end-visitantes" title="Fecha de fin" aria-label="Fecha de fin" />
               </label>
             </div>
-            <span id="visitantes-total" class="count-pill" aria-live="polite">0 registros</span>
             <button id="export-visitantes-btn" class="btn-export button-with-icon" aria-label="Exportar registros de visitantes">
               <span class="icon icon--sm icon-export" aria-hidden="true"></span>
               <span class="button-label">Exportar Excel</span>
@@ -109,8 +111,11 @@
         <!-- Lista de sesiones -->
         <section id="sesiones-lista">
           <div class="controls-area" data-controls="descartes">
+            <div class="controls-count">
+              <span id="sesiones-total" class="count-pill" aria-live="polite">0 sesiones</span>
+            </div>
             <div class="controls-row controls-row--inline">
-              <button class="search-toggle button-with-icon" type="button" aria-expanded="false" aria-controls="search-descartes">
+              <button class="search-toggle button-with-icon" type="button" aria-expanded="false" aria-controls="search-descartes" title="Mostrar búsqueda">
                 <span class="icon icon--sm icon-search" aria-hidden="true"></span>
                 <span class="sr-only">Mostrar búsqueda</span>
               </button>
@@ -131,7 +136,6 @@
                   <input type="date" id="date-end-descartes" title="Fecha de fin" aria-label="Fecha de fin" />
                 </label>
               </div>
-              <span id="sesiones-total" class="count-pill" aria-live="polite">0 sesiones</span>
               <button id="export-descartes-btn" class="btn-export button-with-icon" aria-label="Exportar sesiones de descartes">
                 <span class="icon icon--sm icon-export" aria-hidden="true"></span>
                 <span class="button-label">Exportar Excel</span>
@@ -191,7 +195,7 @@
 
           <div class="controls-area" data-controls="equipos">
             <div class="controls-row controls-row--primary">
-              <button class="search-toggle button-with-icon" type="button" aria-expanded="false" aria-controls="search-equipos">
+              <button class="search-toggle button-with-icon" type="button" aria-expanded="false" aria-controls="search-equipos" title="Mostrar búsqueda">
                 <span class="icon icon--sm icon-search" aria-hidden="true"></span>
                 <span class="sr-only">Mostrar búsqueda</span>
               </button>

--- a/css/consultar.css
+++ b/css/consultar.css
@@ -173,13 +173,24 @@ html.dark-mode .controls-area input[type="search"]{
   justify-content: flex-start;
 }
 
-.controls-area[data-controls] .controls-row--inline > .count-pill {
-  margin-left: auto;
-}
-
 .controls-area[data-controls] .controls-row--inline > .btn-export,
 .controls-area[data-controls] .controls-row--inline > .btn-clear-filters {
   flex: 0 0 auto;
+}
+
+.controls-area[data-controls="visitantes"] .controls-count,
+.controls-area[data-controls="descartes"] .controls-count {
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.controls-area[data-controls="visitantes"] .controls-count {
+  justify-content: flex-end;
+}
+
+.controls-area[data-controls="descartes"] .controls-count {
+  justify-content: flex-end;
 }
 
 .controls-area[data-controls] .btn-clear-filters {
@@ -423,13 +434,8 @@ html.dark-mode .controls-area .date-field {
     flex: 0 0 auto;
   }
 
-  .controls-area[data-controls] .controls-row--inline > .count-pill {
-    margin-left: 0;
-    flex: 0 0 auto;
-  }
-
   .controls-area[data-controls] .controls-row--inline > .btn-export {
-    margin-left: auto;
+    margin-left: 0;
   }
 
   .controls-area[data-controls] .btn-clear-filters,
@@ -488,6 +494,54 @@ html.dark-mode .controls-area .date-field {
   .controls-area[data-controls].search-expanded .btn-export,
   .controls-area[data-controls].search-expanded .btn-clear-filters {
     margin-top: 8px;
+  }
+
+  .controls-area[data-controls="visitantes"] .controls-count,
+  .controls-area[data-controls="descartes"] .controls-count {
+    justify-content: center;
+  }
+
+  .controls-area[data-controls="visitantes"].search-expanded .filters-group,
+  .controls-area[data-controls="descartes"].search-expanded .filters-group {
+    width: auto;
+    flex: 0 0 auto;
+    order: initial;
+    margin-top: 0;
+  }
+
+  .controls-area[data-controls="visitantes"].search-expanded .btn-export,
+  .controls-area[data-controls="visitantes"].search-expanded .btn-clear-filters,
+  .controls-area[data-controls="descartes"].search-expanded .btn-export,
+  .controls-area[data-controls="descartes"].search-expanded .btn-clear-filters {
+    margin-top: 0;
+  }
+}
+
+@media (min-width: 769px) {
+  .controls-area[data-controls="visitantes"],
+  .controls-area[data-controls="descartes"] {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: 16px;
+    row-gap: 12px;
+    align-items: center;
+  }
+
+  .controls-area[data-controls="visitantes"] .controls-row--inline,
+  .controls-area[data-controls="descartes"] .controls-row--inline {
+    grid-column: 1 / 2;
+  }
+
+  .controls-area[data-controls="visitantes"] .controls-count,
+  .controls-area[data-controls="descartes"] .controls-count {
+    grid-column: 2 / 3;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  .controls-area[data-controls="visitantes"] .controls-row--inline > .btn-export,
+  .controls-area[data-controls="descartes"] .controls-row--inline > .btn-export {
+    margin-left: auto;
   }
 }
 
@@ -652,6 +706,22 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
   box-shadow: 0 2px 6px var(--shadow-color);
 }
 
+#table-visitantes th:last-child,
+#table-descartes th:last-child,
+#table-equipos-sesion th:last-child {
+  width: 1%;
+  white-space: nowrap;
+}
+
+#table-visitantes td.table-actions,
+#table-descartes td.table-actions,
+#table-equipos-sesion td.table-actions {
+  width: 1%;
+  white-space: nowrap;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
 /* Variantes */
 .btn-editar         { background-color: #4B5563; }
 .btn-editar:hover   { background-color: #374151; }
@@ -667,37 +737,7 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
   background-color: var(--primary-color);
 }
 
-/* --- Columna ACCIONES sticky (última columna) --- */
-#table-visitantes th:last-child,
-#table-descartes th:last-child,
-#table-equipos-sesion th:last-child {
-  position: sticky;
-  right: 0;
-  z-index: 4;
-  box-shadow: -6px 0 8px -4px rgba(0,0,0,0.08);
-}
-
-#table-visitantes td:last-child,
-#table-descartes td:last-child,
-#table-equipos-sesion td:last-child {
-  position: sticky;
-  right: 0;
-  z-index: 3;
-  background-color: var(--card-bg-color);
-  box-shadow: -6px 0 8px -4px rgba(0,0,0,0.06);
-  min-width: 140px; /* ancho mínimo para botones */
-}
-
 @media (max-width: 768px) {
-  #table-visitantes th:last-child,
-  #table-descartes th:last-child,
-  #table-equipos-sesion th:last-child,
-  #table-visitantes td:last-child,
-  #table-descartes td:last-child,
-  #table-equipos-sesion td:last-child {
-    min-width: 120px;
-  }
-
   .table-actions button {
     padding: 6px;
     width: 36px;

--- a/js/consultar.js
+++ b/js/consultar.js
@@ -465,11 +465,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         <td>${formatDate(visitor.fecha)}</td>
         <td>${formatTime(visitor.hora)}</td>
         <td class="table-actions">
-          <button class="btn-editar button-with-icon" data-id="${visitor.id}" aria-label="Editar visitante">
+          <button class="btn-editar button-with-icon" data-id="${visitor.id}" aria-label="Editar visitante" title="Editar visitante">
             <span class="icon icon--sm icon-edit" aria-hidden="true"></span>
             <span class="button-label">Editar</span>
           </button>
-          <button class="btn-eliminar button-with-icon" data-id="${visitor.id}" aria-label="Eliminar visitante">
+          <button class="btn-eliminar button-with-icon" data-id="${visitor.id}" aria-label="Eliminar visitante" title="Eliminar visitante">
             <span class="icon icon--sm icon-trash" aria-hidden="true"></span>
             <span class="button-label">Eliminar</span>
           </button>
@@ -526,15 +526,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         <td>${session.observacion || '-'}</td>
         <td>${count}</td>
         <td class="table-actions">
-          <button class="btn-view-equipos button-with-icon" data-id="${session.id}" aria-label="Abrir sesión">
+          <button class="btn-view-equipos button-with-icon" data-id="${session.id}" aria-label="Abrir sesión" title="Abrir sesión">
             <span class="icon icon--sm icon-open" aria-hidden="true"></span>
             <span class="button-label">Abrir</span>
           </button>
-          <button class="btn-editar btn-editar-sesion button-with-icon" data-id="${session.id}" aria-label="Editar sesión">
+          <button class="btn-editar btn-editar-sesion button-with-icon" data-id="${session.id}" aria-label="Editar sesión" title="Editar sesión">
             <span class="icon icon--sm icon-edit" aria-hidden="true"></span>
             <span class="button-label">Editar</span>
           </button>
-          <button class="btn-eliminar-sesion button-with-icon" data-id="${session.id}" aria-label="Eliminar sesión">
+          <button class="btn-eliminar-sesion button-with-icon" data-id="${session.id}" aria-label="Eliminar sesión" title="Eliminar sesión">
             <span class="icon icon--sm icon-trash" aria-hidden="true"></span>
             <span class="button-label">Eliminar</span>
           </button>
@@ -615,11 +615,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         <td>${eq.estado_equipo || '-'}</td>
         <td>${eq.motivo_descarte || '-'}</td>
         <td class="table-actions">
-          <button class="btn-editar button-with-icon" data-id="${eq.id}" aria-label="Editar equipo">
+          <button class="btn-editar button-with-icon" data-id="${eq.id}" aria-label="Editar equipo" title="Editar equipo">
             <span class="icon icon--sm icon-edit" aria-hidden="true"></span>
             <span class="button-label">Editar</span>
           </button>
-          <button class="btn-eliminar button-with-icon" data-id="${eq.id}" aria-label="Eliminar equipo">
+          <button class="btn-eliminar button-with-icon" data-id="${eq.id}" aria-label="Eliminar equipo" title="Eliminar equipo">
             <span class="icon icon--sm icon-trash" aria-hidden="true"></span>
             <span class="button-label">Eliminar</span>
           </button>


### PR DESCRIPTION
## Summary
- reorganize the visitor and descartes control bars so the counter sits above the icon row on mobile while keeping desktop alignment with a grid layout
- remove the sticky behaviour from action columns and tighten their width so they scroll naturally without extra padding
- add hover tooltips to icon-only action buttons for clearer feedback

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3177e3798832ab1836f57f4b24a52