### PR TITLE
Fix mobile controls alignment on consultar page

### DIFF
--- a/css/consultar.css
+++ b/css/consultar.css
@@ -308,6 +308,7 @@ html.dark-mode .controls-area[data-controls] .search-toggle {
   gap: 8px;
   height: 42px;
   min-height: 42px;
+  margin: 0;
   padding: 0 16px 0 44px;
   border: 1px solid var(--border-color);
   border-radius: var(--button-radius);


### PR DESCRIPTION
## Summary
- reset the default label margins on consultar date filter pills so they align evenly in mobile controls

## Testing
- Manual verification in a mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68e31cef75f0832a8d94caced66ee951