### PR TITLE
Refine discard controls layout and broom icon

### DIFF
--- a/assets/images/icono-broom.svg
+++ b/assets/images/icono-broom.svg
@@ -1,5 +1,9 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="11" y="2" width="2" height="10" rx="1" fill="currentColor"/>
-  <path d="M7.2 12.5a1 1 0 0 0-.98 1.196l1.2 6A1 1 0 0 0 8.4 20h7.2a1 1 0 0 0 .98-.804l1.2-6A1 1 0 0 0 16.8 12.5H7.2Z" fill="currentColor"/>
-  <path d="M6.5 20.5a1 1 0 0 0 0 2h11a1 1 0 1 0 0-2h-11Z" fill="currentColor"/>
+  <path d="M14.47 2.47a1 1 0 0 1 1.41 0l5.65 5.65a1 1 0 0 1-1.41 1.41L14.47 3.88a1 1 0 0 1 0-1.41Z" fill="currentColor"/>
+  <path d="M12.63 8.13a1 1 0 0 1 1.41 0l1.83 1.83a1 1 0 0 1 0 1.41l-1.3 1.3-3.24-3.24 1.3-1.3Z" fill="currentColor" opacity="0.75"/>
+  <path d="M5.32 11.09a2 2 0 0 1 1.06-1.19l4.78-2.22a2 2 0 0 1 2.21.44l2.62 2.62a2 2 0 0 1 .44 2.21l-2.22 4.78a2 2 0 0 1-1.19 1.06l-5.66 2.41a1.75 1.75 0 0 1-2.32-2.32l2.41-5.66Z" fill="currentColor"/>
+  <path d="M7.93 15.46a.75.75 0 0 1 .95.47l.72 2.16a.75.75 0 0 1-1.42.47l-.72-2.16a.75.75 0 0 1 .47-.95Z" fill="currentColor" opacity="0.65"/>
+  <path d="M10.78 14.5a.75.75 0 0 1 .95.47l.72 2.16a.75.75 0 1 1-1.42.47l-.72-2.16a.75.75 0 0 1 .47-.94Z" fill="currentColor" opacity="0.65"/>
+  <path d="M6.25 20.75c0-.69.56-1.25 1.25-1.25h9c.69 0 1.25.56 1.25 1.25s-.56 1.25-1.25 1.25h-9a1.25 1.25 0 0 1-1.25-1.25Z" fill="currentColor"/>
+  <path d="M4.25 7.5a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1-.75-.75Z" fill="currentColor" opacity="0.45"/>
 </svg>

--- a/consultar.html
+++ b/consultar.html
@@ -194,6 +194,9 @@
           </div>
 
           <div class="controls-area" data-controls="equipos">
+            <div class="controls-count">
+              <span id="equipos-total" class="count-pill" aria-live="polite">0 equipos</span>
+            </div>
             <div class="controls-row controls-row--primary">
               <button class="search-toggle button-with-icon" type="button" aria-expanded="false" aria-controls="search-equipos" title="Mostrar búsqueda">
                 <span class="icon icon--sm icon-search" aria-hidden="true"></span>
@@ -205,7 +208,6 @@
                   id="search-equipos"
                   placeholder="Buscar por descripción, marca, modelo, serie o marbete..." />
               </div>
-              <span id="equipos-total" class="count-pill" aria-live="polite">0 equipos</span>
               <button id="btn-agregar-equipo" class="btn-principal btn-anadir-equipo button-with-icon" type="button">
                 <span class="icon icon--sm icon-plus" aria-hidden="true"></span>
                 <span class="button-label">Añadir Equipo</span>

--- a/css/consultar.css
+++ b/css/consultar.css
@@ -178,7 +178,8 @@ html.dark-mode .controls-area input[type="search"]{
 }
 
 .controls-area[data-controls="visitantes"] .controls-count,
-.controls-area[data-controls="descartes"] .controls-count {
+.controls-area[data-controls="descartes"] .controls-count,
+.controls-area[data-controls="equipos"] .controls-count {
   width: 100%;
   display: flex;
   align-items: center;
@@ -188,7 +189,8 @@ html.dark-mode .controls-area input[type="search"]{
   justify-content: flex-end;
 }
 
-.controls-area[data-controls="descartes"] .controls-count {
+.controls-area[data-controls="descartes"] .controls-count,
+.controls-area[data-controls="equipos"] .controls-count {
   justify-content: flex-end;
 }
 
@@ -273,17 +275,6 @@ html.dark-mode .controls-area[data-controls] .search-toggle {
 
 .controls-area[data-controls="equipos"] .search-field {
   order: 2;
-}
-
-.controls-area[data-controls="equipos"] #equipos-total {
-  order: 3;
-  margin-left: auto;
-  flex: 0 0 auto;
-}
-
-.controls-area[data-controls="equipos"] #btn-agregar-equipo {
-  order: 4;
-  flex: 0 0 auto;
 }
 
 .controls-area[data-controls] .search-field input[type="search"] {
@@ -508,11 +499,29 @@ html.dark-mode .controls-area .date-field {
   .controls-area[data-controls="equipos"].search-expanded #btn-agregar-equipo {
     margin-top: 0;
   }
+
+  .controls-area[data-controls="equipos"] .controls-count {
+    justify-content: center;
+  }
+
+  .controls-area[data-controls="equipos"] .controls-row--primary {
+    width: 100%;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 8px;
+    align-items: stretch;
+  }
+
+  .controls-area[data-controls="equipos"] #btn-agregar-equipo {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 @media (min-width: 769px) {
   .controls-area[data-controls="visitantes"],
-  .controls-area[data-controls="descartes"] {
+  .controls-area[data-controls="descartes"],
+  .controls-area[data-controls="equipos"] {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     column-gap: 16px;
@@ -525,11 +534,16 @@ html.dark-mode .controls-area .date-field {
     grid-column: 1 / 2;
   }
 
+  .controls-area[data-controls="equipos"] .controls-row--primary {
+    grid-column: 1 / 2;
+  }
+
   .controls-area[data-controls="visitantes"] .controls-count,
-  .controls-area[data-controls="descartes"] .controls-count {
+  .controls-area[data-controls="descartes"] .controls-count,
+  .controls-area[data-controls="equipos"] .controls-count {
     grid-column: 2 / 3;
     justify-content: flex-end;
-    align-self: start;
+    align-self: center;
   }
 
   .controls-area[data-controls="visitantes"] .controls-row--inline > .btn-export,


### PR DESCRIPTION
## Summary
- replace the limpiar filtros icon with a new stylized broom SVG
- center the discard session equipment counter above the mobile controls and keep desktop alignment consistent
- align the visitor and discard tab counters with the rest of the desktop controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e325e86ec0832aab36abe54d58ee51