### PR TITLE
Fix consultar counter alignment on desktop

### DIFF
--- a/css/consultar.css
+++ b/css/consultar.css
@@ -532,16 +532,19 @@ html.dark-mode .controls-area .date-field {
   .controls-area[data-controls="visitantes"] .controls-row--inline,
   .controls-area[data-controls="descartes"] .controls-row--inline {
     grid-column: 1 / 2;
+    grid-row: 1;
   }
 
   .controls-area[data-controls="equipos"] .controls-row--primary {
     grid-column: 1 / 2;
+    grid-row: 1;
   }
 
   .controls-area[data-controls="visitantes"] .controls-count,
   .controls-area[data-controls="descartes"] .controls-count,
   .controls-area[data-controls="equipos"] .controls-count {
     grid-column: 2 / 3;
+    grid-row: 1;
     justify-content: flex-end;
     align-self: center;
   }


### PR DESCRIPTION
## Summary
- ensure the desktop grid rows explicitly place the counter and filter controls on the same row
- keep the mobile layout untouched by scoping the change to the existing desktop media query

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e32a40a428832aab086e3b8b58cb6b