### PR TITLE
Fix duplicated hamburger icons on mobile

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -662,7 +662,6 @@ html.dark-mode .theme-btn {
 .hamburger svg {
     width: 26px;
     height: 26px;
-    display: block;
 }
 .icon-dark { display: block; }
 .icon-light { display: none; }


### PR DESCRIPTION
## Summary
- remove the redundant display rule on the hamburger SVG so only the intended light/dark icon is shown

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3302cca60832aaaeecac6dc2f3416