### PR TITLE
Mantener iconos en botones móviles al expandir búsqueda

### DIFF
--- a/css/consultar.css
+++ b/css/consultar.css
@@ -491,14 +491,14 @@ html.dark-mode .controls-area .date-field {
 
   .controls-area[data-controls].search-expanded .btn-export,
   .controls-area[data-controls].search-expanded .btn-clear-filters {
-    width: auto;
-    min-width: 0;
-    padding: 0 16px;
+    width: 42px;
+    min-width: 42px;
+    padding: 0;
   }
 
   .controls-area[data-controls].search-expanded .btn-export .button-label,
   .controls-area[data-controls].search-expanded .btn-clear-filters .button-label {
-    display: inline-flex;
+    display: none;
   }
 
   .controls-area[data-controls="visitantes"] .controls-count,


### PR DESCRIPTION
## Summary
- ajusta los estilos móviles para los botones de exportar y limpiar filtros
- garantiza que con la búsqueda expandida sigan mostrando solo el icono, sin texto adicional

## Testing
- no se realizaron pruebas automatizadas; solo verificación de estilos

------
https://chatgpt.com/codex/tasks/task_e_68e3363db930832a98c7a7b627b50ee6