### PR TITLE
fix: restaurar diseño móvil del detalle de sesión

### DIFF
--- a/consultar.html
+++ b/consultar.html
@@ -174,23 +174,38 @@
               <span class="button-label">Volver a Sesiones</span>
             </button>
             <h2 id="detalle-titulo">Sesión</h2>
-            <span class="detalle-unidad"><strong>Unidad:</strong> <span id="detalle-unidad">—</span></span>
+
+            <div class="detalle-info-grid">
+              <article class="detalle-card detalle-card--principal">
+                <p class="detalle-card-label">Unidad</p>
+                <p class="detalle-card-value" id="detalle-unidad">—</p>
+              </article>
+
+              <!-- Botón toggle SOLO para móvil -->
+              <button id="btn-toggle-detalles" class="btn-secondary btn-toggle button-with-icon" type="button" data-expanded="false">
+                <span class="icon icon--sm icon-arrow-down" aria-hidden="true"></span>
+                <span class="button-label">Ver más detalles</span>
+              </button>
+
+              <!-- Bloque de detalles extra -->
+              <div id="detalle-extra" class="detalle-extra">
+                <article class="detalle-card">
+                  <p class="detalle-card-label">Código SIACE</p>
+                  <p class="detalle-card-value" id="detalle-siace">—</p>
+                </article>
+                <article class="detalle-card">
+                  <p class="detalle-card-label">Fecha</p>
+                  <p class="detalle-card-value" id="detalle-fecha">—</p>
+                </article>
+                <article class="detalle-card">
+                  <p class="detalle-card-label">Técnico</p>
+                  <p class="detalle-card-value" id="detalle-tecnico">—</p>
+                </article>
+              </div>
+            </div>
 
             <!-- 🔥 Observación aparte, siempre debajo -->
             <div id="detalle-observacion" class="detalle-observacion"></div>
-
-            <!-- Botón toggle SOLO para móvil -->
-            <button id="btn-toggle-detalles" class="btn-secondary btn-toggle button-with-icon" type="button" data-expanded="false">
-              <span class="icon icon--sm icon-arrow-down" aria-hidden="true"></span>
-              <span class="button-label">Ver más detalles</span>
-            </button>
-
-            <!-- Bloque de detalles extra -->
-            <div id="detalle-extra" class="detalle-extra">
-              <span><strong>SIACE:</strong> <span id="detalle-siace">—</span></span>
-              <span><strong>Fecha:</strong> <span id="detalle-fecha">—</span></span>
-              <span><strong>Técnico:</strong> <span id="detalle-tecnico">—</span></span>
-            </div>
           </div>
 
           <div class="controls-area" data-controls="equipos">

--- a/css/consultar.css
+++ b/css/consultar.css
@@ -761,6 +761,7 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
 }
 
 /* --- 4) Detalle de Sesión --- */
+
 .detalle-header {
   background-color: var(--card-bg-color);
   padding: 18px;
@@ -768,7 +769,7 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
   box-shadow: 0 2px 10px var(--shadow-color);
   margin-bottom: 18px;
   display: grid;
-  gap: 10px;
+  gap: 16px;
 }
 
 /* Título limpio */
@@ -778,40 +779,113 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
   padding-bottom: 0;
 }
 
+.detalle-info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  align-items: stretch;
+}
+
+.detalle-card {
+  position: relative;
+  padding: 16px 18px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 12%, transparent) 0%, var(--card-bg-color) 55%);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--shadow-color) 70%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 100%;
+}
+
+.detalle-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  background: radial-gradient(circle at top right, color-mix(in srgb, var(--primary-color) 25%, transparent) 0%, transparent 55%);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.detalle-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--primary-color) 15%, transparent);
+  pointer-events: none;
+}
+
+.detalle-card-label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-color) 55%, transparent);
+  font-weight: 700;
+}
+
+.detalle-card-value {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--text-color);
+  font-weight: 600;
+  word-break: break-word;
+}
+
+html.dark-mode .detalle-card {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 28%, transparent) 0%, color-mix(in srgb, var(--card-bg-color) 88%, transparent) 60%);
+  box-shadow: 0 6px 18px color-mix(in srgb, #000000 65%, transparent);
+}
+
+html.dark-mode .detalle-card::before {
+  background: radial-gradient(circle at top right, color-mix(in srgb, var(--primary-color) 45%, transparent) 0%, transparent 55%);
+  opacity: 0.6;
+}
+
+html.dark-mode .detalle-card::after {
+  border-color: color-mix(in srgb, var(--primary-color) 35%, #ffffff14);
+}
+
+html.dark-mode .detalle-card-label {
+  color: color-mix(in srgb, #ffffff 70%, transparent);
+}
+
+html.dark-mode .detalle-card-value {
+  color: #fff;
+}
+
+.detalle-card--principal {
+  grid-column: span 2;
+}
+
+@media (max-width: 1024px) {
+  .detalle-card--principal {
+    grid-column: span 1;
+  }
+}
+
+#detalle-extra {
+  display: contents;
+  font-size: 0.95rem;
+  color: var(--text-color);
+}
+
 /* Botón toggle oculto en escritorio */
 #btn-toggle-detalles {
   display: none;
 }
 
-/* Detalles extra SIEMPRE visibles en escritorio */
-#detalle-extra {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 8px 24px;
-  margin-top: 6px;
-  color: var(--text-color);
-  font-size: 0.95rem;
-  align-items: start;
-}
-#detalle-extra span {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: baseline;
-  column-gap: 6px;
-}
-#detalle-extra span strong {
-  color: var(--text-color);
-}
-
 .detalle-observacion {
   margin-top: 0px;
-  padding: 10px 14px;
+  padding: 12px 16px;
   background-color: var(--card-bg-color);
-  border-radius: 8px;
-  box-shadow: 0 2px 6px var(--shadow-color);
+  border-radius: 10px;
+  box-shadow: 0 4px 12px var(--shadow-color);
   color: var(--text-color);
   font-size: 0.95rem;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
 /* --- En móvil: toggle activo --- */
@@ -834,15 +908,81 @@ html.dark-mode { --table-border-color: color-mix(in srgb, var(--border-color) 50
     background-color: var(--primary-hover-color);
   }
 
+  /* Layout móvil restaurado */
+  .detalle-info-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .detalle-card {
+    background: none;
+    box-shadow: none;
+    border: none;
+    padding: 0;
+    position: static;
+    min-height: auto;
+  }
+
+  .detalle-card::before,
+  .detalle-card::after {
+    content: none;
+  }
+
+  .detalle-card-label {
+    font-size: 0.95rem;
+    letter-spacing: 0;
+    text-transform: none;
+    color: var(--text-color);
+  }
+
+  .detalle-card-value {
+    font-size: 0.95rem;
+    font-weight: 400;
+  }
+
+  .detalle-card-label::after {
+    content: ':';
+    margin-left: 0;
+    margin-right: 4px;
+  }
+
+  .detalle-card--principal {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    gap: 6px;
+    grid-column: auto;
+  }
+
   /* Detalles ocultos por defecto */
   #detalle-extra {
     display: none;
   }
+
   #detalle-extra.open {
     display: flex;
     flex-direction: column;
     gap: 6px;
     margin-top: 8px;
+  }
+
+  #detalle-extra .detalle-card {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    gap: 6px;
+  }
+
+  #detalle-extra .detalle-card-value {
+    flex: 1;
+  }
+
+  .detalle-observacion {
+    padding: 10px 14px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px var(--shadow-color);
+    line-height: 1.4;
   }
 }
 


### PR DESCRIPTION
## Summary
- restaurar en móvil el formato original del bloque de detalles de sesión manteniendo el botón de alternancia
- conservar el nuevo diseño de escritorio ocultando los estilos de tarjeta en pantallas pequeñas y recuperando el aspecto anterior de observación

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e33c9fb3b8832a9433e895c043d247