### PR TITLE
Add Meduca user name mappings

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -815,6 +815,9 @@ function getUserProfile(user) {
 
     const userMappings = {
         'concepcion.kelieser@gmail.com': { name: 'Kevin', role: 'Técnico' },
+        'adalberto.fernandez@meduca.gob.pa': { name: 'Adalberto', role: 'Técnico' },
+        'ronnie.diaz@meduca.gob.pa': { name: 'Ronnie', role: 'Técnico' },
+        'edgar.moran@meduca.gob.pa': { name: 'Edgar', role: 'Técnico' },
         'usuario2@empresa.com': { name: 'Ana', role: 'Técnico' },
         'jefe.departamento@empresa.com': { name: 'Carlos', role: 'Supervisor' }
     };


### PR DESCRIPTION
## Summary
- add explicit profile mappings for three Meduca email addresses so they receive personalized greetings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec849edc54832a8b35ecb1a5afa34e